### PR TITLE
Update Maven repository URL to point to releases

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,7 +13,7 @@ dependencyResolutionManagement {
         mavenCentral()
         maven {
             name = "OneLiteFeatherRepository"
-            url = uri("https://repo.onelitefeather.dev/onelitefeather")
+            url = uri("https://repo.onelitefeather.dev/onelitefeather-releases")
             if (System.getenv("CI") != null) {
                 credentials {
                     username = System.getenv("ONELITEFEATHER_MAVEN_USERNAME")


### PR DESCRIPTION
## Overview
This PR should fix building with our dependency Aves

## Description
The url was changed from /onelitefeather to /onelitefeather-releases, as it is the desired url to pull from for the backend.
```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [ ] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/OneLiteFeatherNET/.github/blob/main/CONTRIBUTING.md).
```
