### PR TITLE
ci: pin reusable workflows to v2.0.1

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -3,5 +3,5 @@ on: [pull_request]
 
 jobs:
   build:
-    uses: OneLiteFeatherNET/workflows/.github/workflows/gradle-build-pr.yml@claude/implement-release-please-9inVJ
+    uses: OneLiteFeatherNET/workflows/.github/workflows/gradle-build-pr.yml@v2.0.1
     secrets: inherit

--- a/.github/workflows/close-invalid-prs.yml
+++ b/.github/workflows/close-invalid-prs.yml
@@ -5,6 +5,6 @@ on:
 
 jobs:
   close:
-    uses: OneLiteFeatherNET/workflows/.github/workflows/close-invalid-prs.yml@v2.0.0
+    uses: OneLiteFeatherNET/workflows/.github/workflows/close-invalid-prs.yml@v2.0.1
     with:
       protected-branch: main

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,5 +5,5 @@ on:
 
 jobs:
   publish:
-    uses: OneLiteFeatherNET/workflows/.github/workflows/gradle-publish.yml@v2.0.0
+    uses: OneLiteFeatherNET/workflows/.github/workflows/gradle-publish.yml@v2.0.1
     secrets: inherit

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   release:
-    uses: OneLiteFeatherNET/workflows/.github/workflows/release-please.yml@v2.0.0
+    uses: OneLiteFeatherNET/workflows/.github/workflows/release-please.yml@v2.0.1


### PR DESCRIPTION
## Summary
- `build-pr.yml`: temporären Branch-Pin (`@claude/implement-release-please-9inVJ`) auf das offizielle `@v2.0.1` umgestellt.
- `publish.yaml`, `release-please.yaml`, `close-invalid-prs.yml`: von `@v2.0.0` auf `@v2.0.1` gebumpt (Konsistenz, eine Pin-Stelle pro Projekt).

## Warum v2.0.1
v2.0.1 ([Release-Notes](https://github.com/OneLiteFeatherNET/workflows/releases/tag/v2.0.1)) enthält:
- Matrix-Test-Artifact-Isolation (kein `merge-multiple` mehr) — verhindert das XML-Aggregations-Problem in PR #140.
- Dedup des `junit_files`-Globs — keine doppelten Test-Counts in PR-Kommentaren mehr.

Renovate wird zukünftige Patches/Minor-Bumps automatisch öffnen.

https://claude.ai/code/session_01DbyhbsRLEJ2EfGRppFnDY6

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbyhbsRLEJ2EfGRppFnDY6)_