### PR TITLE
Light engine for the lobby world + publish trigger fix

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,7 +1,11 @@
 name: Publish JAR
 on:
   push:
-    tags: ["v*"]
+    tags:
+      # release-please tags releases without a leading "v" (e.g. 1.10.17);
+      # also keep matching legacy "v"-prefixed tags.
+      - "[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   publish:

--- a/common/src/main/java/net/onelitefeather/titan/common/map/MapProvider.java
+++ b/common/src/main/java/net/onelitefeather/titan/common/map/MapProvider.java
@@ -20,6 +20,7 @@ import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.instance.InstanceContainer;
+import net.minestom.server.instance.LightingChunk;
 import net.minestom.server.instance.anvil.AnvilLoader;
 import net.minestom.server.utils.chunk.ChunkUtils;
 import net.onelitefeather.titan.common.config.AppConfig;
@@ -72,6 +73,10 @@ public final class MapProvider {
 
     private void loadMapData() {
         var lobbyData = this.fileHandler.load(this.mapPool.getMapEntry().path().resolve(AppConfig.MAP_FILE_NAME), LobbyMap.class);
+        // Use LightingChunk so the world is actually lit: it computes and sends
+        // sky/block light. Plain DynamicChunks send no light, leaving the lobby
+        // pitch black. Must be set before any chunk is loaded by the AnvilLoader.
+        this.instance.setChunkSupplier(LightingChunk::new);
         this.instance.setChunkLoader(new AnvilLoader(mapPool.getMapEntry().path()));
         try {
             this.activeLobby = lobbyData.orElse(LobbyMap.lobbyMapBuilder().build());


### PR DESCRIPTION
## Summary
- **fix(map): use LightingChunk so the world is lit** — the world instance used plain `DynamicChunk`s, which send no light data, leaving the lobby pitch black. Set the `LightingChunk` supplier on the instance before the AnvilLoader loads any chunk so sky/block light is computed and sent to clients (covers both `:app` and `:setup` via the shared `MapProvider`).
- **ci: publish on release-please tags without a leading `v`** — release-please tags releases as bare semver (e.g. `1.10.17`); the old `v*` filter never matched, so the publish step never ran. Now matches both bare-semver and legacy `v`-prefixed tags.

## Testing
Lobby boots standalone and binds on :25565 (~1.7s); chunks load as `LightingChunk` without errors. Verified the server answers a Minecraft status ping (1.21.11, protocol 774).

🤖 Generated with [Claude Code](https://claude.com/claude-code)