### PR TITLE
aves from BOM + lobby relight + world/lighting docs

### DIFF
--- a/common/src/main/java/net/onelitefeather/titan/common/map/MapProvider.java
+++ b/common/src/main/java/net/onelitefeather/titan/common/map/MapProvider.java
@@ -19,6 +19,7 @@ import com.google.gson.Gson;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
+import net.minestom.server.event.instance.InstanceChunkLoadEvent;
 import net.minestom.server.instance.InstanceContainer;
 import net.minestom.server.instance.LightingChunk;
 import net.minestom.server.instance.anvil.AnvilLoader;
@@ -52,6 +53,11 @@ public final class MapProvider {
     private MapProvider(@NotNull Path path, @NotNull InstanceContainer instance, Function<Stream<Path>, List<MapEntry>> filterMaps) {
         this.mapPool = new MapPool(path.resolve(MAP_PATH), filterMaps);
         this.instance = instance;
+        // "Exploration" lighting: relight each chunk as it is loaded so regions
+        // light up while players explore into new map sections (anvil chunks
+        // otherwise stay dark until a block update triggers a relight).
+        this.instance.eventNode().addListener(InstanceChunkLoadEvent.class, event ->
+                LightingChunk.relight(event.getInstance(), List.of(event.getChunk())));
         var typeAdapter = new PositionGsonAdapter();
         this.gson = new Gson().newBuilder().registerTypeAdapter(Pos.class, typeAdapter).registerTypeAdapter(Vec.class, typeAdapter).create();
         this.fileHandler = new GsonFileHandler(this.gson);
@@ -77,6 +83,10 @@ public final class MapProvider {
         // sky/block light. Plain DynamicChunks send no light, leaving the lobby
         // pitch black. Must be set before any chunk is loaded by the AnvilLoader.
         this.instance.setChunkSupplier(LightingChunk::new);
+        // Freeze the lobby at midday so it stays bright; otherwise the default
+        // day/night cycle keeps advancing and the world renders dark.
+        this.instance.setTime(6000);
+        this.instance.setTimeRate(0);
         this.instance.setChunkLoader(new AnvilLoader(mapPool.getMapEntry().path()));
         try {
             this.activeLobby = lobbyData.orElse(LobbyMap.lobbyMapBuilder().build());

--- a/common/src/main/java/net/onelitefeather/titan/common/map/MapProvider.java
+++ b/common/src/main/java/net/onelitefeather/titan/common/map/MapProvider.java
@@ -56,8 +56,7 @@ public final class MapProvider {
         // "Exploration" lighting: relight each chunk as it is loaded so regions
         // light up while players explore into new map sections (anvil chunks
         // otherwise stay dark until a block update triggers a relight).
-        this.instance.eventNode().addListener(InstanceChunkLoadEvent.class, event ->
-                LightingChunk.relight(event.getInstance(), List.of(event.getChunk())));
+        this.instance.eventNode().addListener(InstanceChunkLoadEvent.class, event -> LightingChunk.relight(event.getInstance(), List.of(event.getChunk())));
         var typeAdapter = new PositionGsonAdapter();
         this.gson = new Gson().newBuilder().registerTypeAdapter(Pos.class, typeAdapter).registerTypeAdapter(Vec.class, typeAdapter).create();
         this.fileHandler = new GsonFileHandler(this.gson);

--- a/docs/exploration-lighting.md
+++ b/docs/exploration-lighting.md
@@ -1,0 +1,105 @@
+# Exploration Lighting (per-player region reveal)
+
+## Idea
+
+Regions of the lobby/world should start **unlit (dark)** for a player and
+**light up as that player explores them** — a "fog of war" / map-reveal effect
+like in many exploration games. The reveal is **per player**: what one player
+has discovered does not affect what another player sees. Each player builds up
+their own lit area as they move through the world.
+
+## Two modes
+
+There are two distinct behaviours, and they must not be confused:
+
+1. **Lobby = complete relight (now).** The whole lobby is lit. Maps are large
+   (~18–20k populated chunks each), so we do **not** pre-load and relight every
+   chunk at boot. Instead `MapProvider` relights each chunk as it is loaded, so
+   everything is lit by the time it is visible — no dark areas, no visible
+   reveal.
+2. **Special maps = deliberate darkening + per-player reveal (later).** Some
+   maps should be **deliberately dark** and only light up per player as they
+   explore (fog-of-war). This reuses the "anvil chunk stays dark until relit"
+   behaviour on purpose, gated per map, and is layered per player.
+
+## Current state (lobby, instance-level)
+
+`MapProvider` does an **instance-wide** relight:
+
+- The world instance uses `LightingChunk` (`instance.setChunkSupplier(LightingChunk::new)`).
+- An `InstanceChunkLoadEvent` listener relights every chunk as it is loaded
+  (`LightingChunk.relight(instance, List.of(chunk))`), because anvil chunks
+  otherwise stay dark until a block update triggers a relight.
+- Lobby time is frozen at midday (`setTime(6000)` + `setTimeRate(0)`) so lit
+  chunks render bright.
+
+This makes the lobby fully lit (mode 1). The lighting is **shared**: a chunk is
+lit once for everyone. It is also the foundation for mode 2 — the per-player
+reveal just chooses whether to send the real light or a dark override per
+player.
+
+## Goal: per-player reveal
+
+Each player has their own set of **discovered chunks**. A chunk a player has
+not discovered yet is shown **dark** to them; once they discover it, it is
+shown with its real (relit) light — and only for that player.
+
+### Discovery trigger (to decide)
+
+A chunk becomes "discovered" for a player when, e.g.:
+
+- the player enters the chunk, **or**
+- the player comes within `N` blocks / a configurable reveal radius, **or**
+- the chunk enters line-of-sight.
+
+Reveal radius and trigger should be configurable (likely via `AppConfig` /
+a Togglz feature flag, consistent with `TitanFeatures`).
+
+### Technical approach in Minestom
+
+Minestom stores light per chunk in the instance (shared). To make it
+per-player we override the light **on the wire**, per player:
+
+1. **Track discovered chunks per player** — e.g. a `Set<Long>` of packed chunk
+   keys on the player (custom `TitanPlayer` already exists), persisted per
+   session (and optionally to storage for permanent reveal).
+2. **Send dark light for undiscovered chunks.** When a chunk is sent to a
+   player who has not discovered it, send the chunk with zeroed sky/block light
+   (a "dark" `UpdateLightPacket` / chunk-data light section) instead of the
+   real light.
+3. **Reveal on discovery.** When the discovery trigger fires for a player +
+   chunk, mark it discovered and send that player an `UpdateLightPacket` with
+   the chunk's real (relit) light. Optionally animate the reveal by revealing
+   neighbouring chunks outward.
+4. **Real light source.** The instance still computes correct light via
+   `LightingChunk` (the global relight above); the per-player layer only chooses
+   whether to send the real light or a dark override to each player.
+
+### Open questions / challenges
+
+- **Packet interception:** Minestom sends chunk data + light when a chunk
+  enters a player's view. We need a hook to substitute dark light for
+  undiscovered chunks (custom chunk-send path, or post-send dark
+  `UpdateLightPacket`, or a per-player light override layer).
+- **Border seams:** skylight propagates across chunk borders; revealing a
+  single chunk while neighbours are dark may show hard edges. Reveal in small
+  batches / with a radius to soften.
+- **Performance:** per-player light packets scale with players × chunks; cache
+  the "dark" light payload and only compute real light once (shared) + resend.
+- **Persistence:** decide whether discovered regions persist across sessions
+  (per-player save) or reset on rejoin.
+- **Cross-version time API:** time is frozen with the legacy
+  `setTime`/`setTimeRate`; newer Minestom replaces this with the world
+  `Clock` API (`instance.defaultClock().rate(0f)`) — migrate when Minestom is
+  bumped.
+
+## Next steps
+
+1. Add a **per-map "dark/reveal" flag** (e.g. in the map metadata / `AppConfig`)
+   so the lobby stays fully lit (mode 1) while special maps opt into deliberate
+   darkening (mode 2). Lit maps skip the dark override entirely.
+2. Settle the discovery trigger + reveal radius and where it is configured.
+3. Add per-player discovered-chunk tracking on `TitanPlayer`.
+4. Implement the dark-light override on chunk send + reveal `UpdateLightPacket`
+   on discovery (only for maps with the dark/reveal flag set).
+5. Keep the instance-level `LightingChunk` relight as the real-light source.

--- a/docs/world-conversion.md
+++ b/docs/world-conversion.md
@@ -1,0 +1,110 @@
+# Converting worlds to a newer Minecraft version (CLI)
+
+Titan runs on Minestom, which only loads worlds in the **exact** Minecraft
+version it targets (see the `minestom` version in `settings.gradle.kts`, e.g.
+`1.21.11`). Worlds saved by older versions fail to load — e.g.
+`Unknown block minecraft:chain` because `chain` was renamed to `iron_chain` in
+1.21.x.
+
+The data-fix rules that perform these migrations live inside Minecraft
+(`net.minecraft`), so neither Mojang's DataFixerUpper nor PaperMC/DataConverter
+can run standalone in Minestom. The robust way is a **one-off offline upgrade
+with the official Minecraft server jar** (`--forceUpgrade`), which runs the real
+DataFixerUpper over every chunk. Do this whenever the worlds are older than the
+targeted Minestom version.
+
+## Prerequisites
+
+- A JDK matching the target Minecraft version (1.21.11 needs **Java 21+**;
+  newer versions may need Java 25). `java -version` must satisfy it.
+- Run from the repo root. Worlds live in `worlds/` and `test-server/worlds/`.
+
+## 1. Download the target server jar
+
+```bash
+MC_VERSION=1.21.11   # must match the -<version> suffix of net.minestom:minestom
+
+VJSON=$(curl -s https://launchermeta.mojang.com/mc/game/version_manifest_v2.json \
+  | python3 -c "import sys,json;d=json.load(sys.stdin);print(next(v['url'] for v in d['versions'] if v['id']=='$MC_VERSION'))")
+SJAR=$(curl -s "$VJSON" | python3 -c "import sys,json;print(json.load(sys.stdin)['downloads']['server']['url'])")
+curl -s -o /tmp/mc-server.jar "$SJAR"
+echo "server jar: $(ls -la /tmp/mc-server.jar | awk '{print $5}') bytes"
+```
+
+## 2. Upgrade one world
+
+`--forceUpgrade` runs DataFixerUpper over the level on boot, then starts the
+server; once the upgrade is done we stop it. Repeat per world.
+
+```bash
+upgrade_world() {            # usage: upgrade_world <worlds-root> <world-name>
+  local ROOT="$1" W="$2" C="/tmp/conv_$2"
+  rm -rf "$C"; mkdir -p "$C"
+  cp /tmp/mc-server.jar "$C/server.jar"
+  echo "eula=true" > "$C/eula.txt"
+  cp -r "$ROOT/$W" "$C/$W"
+  printf 'level-name=%s\nonline-mode=false\nmax-players=1\nspawn-protection=0\n' "$W" > "$C/server.properties"
+
+  ( cd "$C" && java -Xmx2G -jar server.jar --nogui --forceUpgrade > convert.log 2>&1 & echo $! > pid )
+  local pid=$(cat "$C/pid")
+  # wait until the upgrade finished and the server is up, then stop it
+  for i in $(seq 1 180); do grep -q "Done (" "$C/convert.log" && break; kill -0 "$pid" 2>/dev/null || break; sleep 1; done
+  sleep 1; kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
+
+  # copy only the upgraded world content back (no server cruft: DIM-1/DIM1,
+  # datapacks, playerdata, data/* indexes, logs, …)
+  for sub in region entities poi; do rm -rf "$ROOT/$W/$sub"; cp -r "$C/$W/$sub" "$ROOT/$W/$sub"; done
+  cp "$C/$W/level.dat" "$ROOT/$W/level.dat"
+  [ -f "$C/$W/level.dat_old" ] && cp "$C/$W/level.dat_old" "$ROOT/$W/level.dat_old"
+  echo "$W upgraded ($(grep -oE '[0-9]+% completed' "$C/convert.log" | tail -1))"
+}
+
+# all lobby worlds (+ the CloudNet test-server copies)
+for W in winter halloween world world_generic; do upgrade_world worlds "$W"; done
+for W in winter halloween world world_generic; do upgrade_world test-server/worlds "$W"; done
+```
+
+## 3. Drop server-generated cruft
+
+The server run creates extra files we do not want in the repo:
+
+```bash
+git clean -fd worlds/ test-server/worlds/     # removes untracked data/*.dat, etc.
+git checkout -- worlds/*/data test-server/worlds/*/data   # if data/ was tracked/empty
+```
+
+## 4. Verify
+
+```bash
+# DataVersion should be the target version's (e.g. 4671 for 1.21.11)
+python3 -c "import gzip,struct;d=gzip.open('worlds/winter/level.dat','rb').read();i=d.find(b'DataVersion');print('DataVersion=',struct.unpack('>i',d[i+11:i+15])[0])"
+
+# no pre-rename blocks should remain, e.g. plain minecraft:chain
+python3 - <<'PY'
+import zlib,struct,glob,re
+chain=iron=0
+for f in glob.glob('worlds/*/region/*.mca'):
+    d=open(f,'rb').read(); o=b''
+    for i in range(1024):
+        off=struct.unpack('>I',b'\x00'+d[i*4:i*4+3])[0]
+        if off==0: continue
+        s=off*4096; l=struct.unpack('>I',d[s:s+4])[0]; c=d[s+4]; r=d[s+5:s+4+l]
+        try: o += zlib.decompress(r) if c==2 else r
+        except Exception: pass
+    chain += len(re.findall(rb'minecraft:chain(?![_a-z])', o)); iron += o.count(b'minecraft:iron_chain')
+print('plain chain=',chain,'iron_chain=',iron)   # expect plain chain=0
+PY
+```
+
+Finally launch Titan and confirm the world loads without `Unknown block` errors
+(`java -jar app/build/libs/app-titan.jar`, then a status ping or client join).
+
+## Notes
+
+- Source versions seen here: 1.19.4 (DataVersion 3120), 1.20.1 (3337),
+  1.20.4 (3700) → upgraded to 1.21.11 (4671).
+- The server also writes empty `DIM-1`/`DIM1` (nether/end), `datapacks/`,
+  `playerdata/` and structure index files — do **not** commit those; the steps
+  above copy back only `region/`, `entities/`, `poi/` and `level.dat`.
+- After bumping the targeted Minecraft/Minestom version, re-run this whole
+  process with the new `MC_VERSION`.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,7 +42,7 @@ dependencyResolutionManagement {
             // Minestom
             library("aonyx-bom", "net.onelitefeather", "aonyx-bom").versionRef("aonyx-bom")
             library("minestom","net.minestom", "minestom").withoutVersion()
-            library("aves", "net.theevilreaper", "aves").version("1.14.1")
+            library("aves", "net.theevilreaper", "aves").withoutVersion()
             library("adventure.minimessage", "net.kyori", "adventure-text-minimessage").withoutVersion()
             library("butterfly-minestom", "net.onelitefeather", "butterfly-minestom").versionRef("butterfly")
 


### PR DESCRIPTION
## Summary
- **build(deps): let the aonyx BOM manage the aves version** — drop the explicit `aves` pin in the version catalog; it resolves to 1.14.1 from `aonyx-bom` (verified). No more separate pin/renovate for aves.
- **feat(map): relight chunks on load and freeze lobby time** — anvil chunks loaded as `LightingChunk` stay dark until a block update; relight each chunk on `InstanceChunkLoadEvent` so the lobby is lit as chunks load, and freeze time at midday. (Was committed after PR #153 was opened, so it never reached main.)
- **docs**: per-player exploration-lighting design (the future "dark until explored" / deliberate-darkening mechanic) and a CLI guide for converting worlds to a newer Minecraft version (`--forceUpgrade`).

## Testing
`:app:shadowJar` builds; aves resolves to 1.14.1 from the BOM on `:common` and `:app` compile classpaths. Lobby boots standalone, binds, answers a status ping; world loads lit (no `Unknown block`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)