### PR TITLE
Fix: publish never runs after a release (chain it into release-please)

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -8,5 +8,24 @@ permissions:
   pull-requests: write
 
 jobs:
-  release:
-    uses: OneLiteFeatherNET/workflows/.github/workflows/release-please.yml@v2.1.0
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+    steps:
+      - name: Run release-please
+        id: release
+        uses: googleapis/release-please-action@v5
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+
+  # Tags created by release-please use the GITHUB_TOKEN, whose push event does
+  # NOT trigger other workflows (so publish.yaml never fired on a release).
+  # Chain the publish in the same run instead, only when a release was created.
+  publish:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: OneLiteFeatherNET/workflows/.github/workflows/gradle-publish.yml@v2.1.0
+    secrets: inherit


### PR DESCRIPTION
## Problem
`publish.yaml` triggers on `push: tags`, but release-please creates the tag with the default `GITHUB_TOKEN`. **Pushes made with `GITHUB_TOKEN` do not trigger other workflows** (GitHub's anti-recursion rule), so the publish never ran after a release — regardless of the tag pattern.

## Fix
Run release-please **inline** in `release-please.yaml` so its `release_created` output is available, and **chain** the `gradle-publish` reusable workflow in the same run, guarded by `if: release_created == 'true'`. This run is triggered by the human merge to `main`, not by the bot tag, so it fires normally. The publish also picks up the AOT cache artifact automatically.

`publish.yaml` is left in place as the manual (human-pushed tag) re-publish path.

> Note: the centralized `release-please.yml@v2.1.0` exposes no outputs and accepts no token, so chaining had to be done by inlining the action here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)