### PR TITLE
fix(app): bundle the Kotlin stdlib for minestom-ce extension loading

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,6 +36,11 @@ dependencies {
     // Guava was previously pulled in transitively by CloudNet; LuckPerms expects
     // it (unrelocated) on the classpath, so bundle it explicitly now.
     implementation("com.google.guava:guava:33.4.0-jre")
+    // minestom-ce-extensions loads extension dependencies via a Kotlin class
+    // (net.minestom.dependencies.maven.MavenRepository); without the Kotlin stdlib
+    // on the classpath ExtensionBootstrap init crashes with
+    // NoClassDefFoundError: kotlin/jvm/internal/Intrinsics. Bundle it.
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.2.0")
 
     testImplementation(platform(libs.aonyx.bom))
     testImplementation(libs.minestom)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,12 +35,12 @@ dependencies {
     // references nor bundles it.
     // Guava was previously pulled in transitively by CloudNet; LuckPerms expects
     // it (unrelocated) on the classpath, so bundle it explicitly now.
-    implementation("com.google.guava:guava:33.4.0-jre")
+    implementation(libs.guava)
     // minestom-ce-extensions loads extension dependencies via a Kotlin class
     // (net.minestom.dependencies.maven.MavenRepository); without the Kotlin stdlib
     // on the classpath ExtensionBootstrap init crashes with
     // NoClassDefFoundError: kotlin/jvm/internal/Intrinsics. Bundle it.
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.2.0")
+    implementation(libs.kotlin.stdlib.jdk8)
 
     testImplementation(platform(libs.aonyx.bom))
     testImplementation(libs.minestom)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,6 +43,9 @@ dependencyResolutionManagement {
 
             version("tomcat-annotations-api", "6.0.53")
 
+            version("guava", "33.4.0-jre")
+            version("kotlin", "2.2.0")
+
             version("mockito", "5.23.0")
 
             // Minestom
@@ -75,6 +78,11 @@ dependencyResolutionManagement {
 
             library("cyano", "net.onelitefeather", "cyano").withoutVersion()
             library("mockito", "org.mockito", "mockito-core").versionRef("mockito")
+
+            // Guava: unrelocated, expected by LuckPerms (was transitive via CloudNet).
+            library("guava", "com.google.guava", "guava").versionRef("guava")
+            // Kotlin stdlib: needed by minestom-ce-extensions' MavenRepository.kt.
+            library("kotlin-stdlib-jdk8", "org.jetbrains.kotlin", "kotlin-stdlib-jdk8").versionRef("kotlin")
         }
     }
 }


### PR DESCRIPTION
## Problem
On a real CloudNet service the lobby crashed during `ExtensionBootstrap` init:
```
NoClassDefFoundError: kotlin/jvm/internal/Intrinsics
  at net.minestom.dependencies.maven.MavenRepository.<init>(MavenRepository.kt)
  at net.minestom.server.extensions.ExtensionManager.loadDependencies(...)
  at net.hollowcube.minestom.extensions.ExtensionBootstrap.<init>
```
minestom-ce-extensions resolves extension dependencies through a Kotlin class (`MavenRepository.kt`), but the Kotlin stdlib was not on the classpath / bundled in the fat jar.

## Fix
Bundle `org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.2.0` in `:app`.

## Testing
Fat jar now contains `kotlin/jvm/internal/Intrinsics`; standalone boots cleanly (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)