### PR TITLE
fix(bridge): route player server-switching through the bridge extension

### DIFF
--- a/bridge/build.gradle.kts
+++ b/bridge/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
 
     compileOnly(platform(libs.cloudnet.bom))
     compileOnly(libs.cloudnet.driver.api)
+    compileOnly(libs.cloudnet.bridge)
     compileOnly(libs.cloudnet.bridge.impl)
 }
 

--- a/bridge/src/main/java/net/onelitefeather/titan/bridge/TitanBridgePermissionExtension.java
+++ b/bridge/src/main/java/net/onelitefeather/titan/bridge/TitanBridgePermissionExtension.java
@@ -17,24 +17,34 @@ package net.onelitefeather.titan.bridge;
 
 import eu.cloudnetservice.driver.registry.ServiceRegistry;
 import eu.cloudnetservice.modules.bridge.impl.platform.minestom.MinestomPermissionChecker;
+import eu.cloudnetservice.modules.bridge.player.PlayerManager;
+import eu.cloudnetservice.modules.bridge.player.executor.PlayerExecutor;
+import eu.cloudnetservice.modules.bridge.player.executor.ServerSelectorType;
+import java.util.UUID;
 import net.minestom.server.extensions.Extension;
+import net.onelitefeather.titan.common.deliver.ServerConnector;
+import net.onelitefeather.titan.common.deliver.TitanServerConnector;
 import net.onelitefeather.titan.common.permission.TitanPermissionBridge;
 
 /**
- * Minestom extension that makes the CloudNet bridge resolve permissions through LuckPerms.
+ * Minestom extension that wires the CloudNet bridge to Titan across the classloader boundary.
  *
- * <p>The bridge injects its permission checker from CloudNet's {@link ServiceRegistry} and ships
- * a default ({@code MinestomDefaultPermissionChecker}) that merely checks {@code
- * player.getPermissionLevel() > 0} and ignores the permission node entirely. This extension
- * registers a LuckPerms-backed checker and marks it as the default, so the bridge picks it up on
- * its next lazy lookup.
+ * <p>Both pieces of glue need bridge classes ({@link MinestomPermissionChecker},
+ * {@link PlayerManager}) that are only visible inside the bridge's extension classloader, so they
+ * cannot live in the application. By declaring a dependency on the {@code CloudNet_Bridge}
+ * extension (see {@code extension.json}), this extension loads after the bridge and shares its
+ * classloader hierarchy. It exchanges only JDK types with the application through the holders in
+ * {@code common}.
  *
- * <p>The checker cannot live in the application: {@link MinestomPermissionChecker} is a bridge
- * class only visible inside the bridge's extension classloader. By declaring a dependency on the
- * {@code CloudNet_Bridge} extension (see {@code extension.json}), this extension loads after the
- * bridge and shares its classloader hierarchy, so it can both implement the interface and reach
- * the registry. The actual permission lookup is delegated back to the application realm through
- * {@link TitanPermissionBridge}, which exchanges only JDK types.
+ * <ul>
+ * <li><b>Permissions:</b> the bridge ships a default checker that only inspects {@code
+ *       player.getPermissionLevel()}. This registers a LuckPerms-backed checker and marks it the
+ * registry default; the lookup is delegated back to the application via
+ * {@link TitanPermissionBridge}.
+ * <li><b>Server switching:</b> installs a {@link ServerConnector} (used by
+ * {@code MessageChannelDeliver}) that connects players through the bridge
+ * {@link PlayerManager} / {@link PlayerExecutor}.
+ * </ul>
  */
 public final class TitanBridgePermissionExtension extends Extension {
 
@@ -42,6 +52,29 @@ public final class TitanBridgePermissionExtension extends Extension {
     public void initialize() {
         MinestomPermissionChecker checker = (player, permission) -> TitanPermissionBridge.hasPermission(player.getUuid(), permission);
         ServiceRegistry.registry().registerProvider(MinestomPermissionChecker.class, "titan-luckperms", checker).markAsDefaultService();
+
+        TitanServerConnector.setConnector(new ServerConnector() {
+            @Override
+            public void connectToTask(UUID playerId, String taskName) {
+                PlayerExecutor executor = playerExecutor(playerId);
+                if (executor != null) {
+                    executor.connectToTask(taskName, ServerSelectorType.LOWEST_PLAYERS);
+                }
+            }
+
+            @Override
+            public void connectToServer(UUID playerId, String serviceName) {
+                PlayerExecutor executor = playerExecutor(playerId);
+                if (executor != null) {
+                    executor.connect(serviceName);
+                }
+            }
+        });
+    }
+
+    private static PlayerExecutor playerExecutor(UUID playerId) {
+        var registration = ServiceRegistry.registry().registration(PlayerManager.class, "PlayerManager");
+        return registration == null ? null : registration.serviceInstance().playerExecutor(playerId);
     }
 
     @Override

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -11,12 +11,9 @@ dependencies {
     implementation(libs.aves)
     implementation(libs.adventure.minimessage)
 
-    // CloudNet is provided by the CloudNet wrapper at runtime, so compile against
-    // it but do not bundle it into the fat jar (see DeliverProvider for the
-    // standalone no-op fallback).
-    compileOnly(platform(libs.cloudnet.bom))
-    compileOnly(libs.cloudnet.jvm.wrapper)
-    compileOnly(libs.cloudnet.bridge)
+    // No CloudNet here anymore: anything touching the CloudNet bridge lives in the
+    // :bridge extension; common only talks to it through the JDK-typed
+    // TitanServerConnector / TitanPermissionBridge holders.
 
     testImplementation(platform(libs.aonyx.bom))
     testImplementation(libs.minestom)

--- a/common/src/main/java/net/onelitefeather/titan/common/deliver/MessageChannelDeliver.java
+++ b/common/src/main/java/net/onelitefeather/titan/common/deliver/MessageChannelDeliver.java
@@ -15,14 +15,15 @@
  */
 package net.onelitefeather.titan.common.deliver;
 
-import eu.cloudnetservice.driver.inject.InjectionLayer;
-import eu.cloudnetservice.driver.registry.ServiceRegistry;
-import eu.cloudnetservice.modules.bridge.player.PlayerManager;
-import eu.cloudnetservice.modules.bridge.player.executor.ServerSelectorType;
 import net.minestom.server.entity.Player;
 import net.onelitefeather.deliver.DeliverComponent;
 import net.onelitefeather.titan.api.deliver.Deliver;
 
+/**
+ * Sends a player to another CloudNet service. The actual switch runs in the CloudNet bridge
+ * extension realm (the bridge {@code PlayerManager} is not on the application classpath); this
+ * class only forwards the request through {@link TitanServerConnector} using JDK types.
+ */
 public final class MessageChannelDeliver implements Deliver {
 
     @Override
@@ -32,24 +33,13 @@ public final class MessageChannelDeliver implements Deliver {
         if (component == null)
             return;
 
-        var serviceRegistry = InjectionLayer.ext().instance(ServiceRegistry.class);
-        if (serviceRegistry == null)
-            return;
-
-        var playerManager = serviceRegistry.registration(PlayerManager.class, "playerManager");
-        if (playerManager == null)
-            return;
-
-        var executor = playerManager.serviceInstance().playerExecutor(player.getUuid());
         switch (component) {
             case DeliverComponent.TaskComponent taskComponent ->
-                executor.connectToTask(taskComponent.taskName(), ServerSelectorType.LOWEST_PLAYERS);
+                TitanServerConnector.connectToTask(player.getUuid(), taskComponent.taskName());
             case DeliverComponent.ServerDeliverComponent serverDeliverComponent ->
-                executor.connect(serverDeliverComponent.gameServer());
+                TitanServerConnector.connectToServer(player.getUuid(), serverDeliverComponent.gameServer());
             case null, default ->
                 throw new IllegalStateException("Unexpected value: " + component.type());
         }
-        ;
-
     }
 }

--- a/common/src/main/java/net/onelitefeather/titan/common/deliver/ServerConnector.java
+++ b/common/src/main/java/net/onelitefeather/titan/common/deliver/ServerConnector.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2025 OneLiteFeather Network
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.onelitefeather.titan.common.deliver;
+
+import java.util.UUID;
+
+/**
+ * Connects a player to another CloudNet service. Implemented in the CloudNet bridge extension
+ * realm (where the bridge {@code PlayerManager} is visible) and invoked from the application via
+ * {@link TitanServerConnector}. Only JDK types cross the classloader boundary.
+ */
+public interface ServerConnector {
+
+    /**
+     * Connects the player to the best service of the given task.
+     *
+     * @param playerId the player's unique id
+     * @param taskName the CloudNet task to connect to
+     */
+    void connectToTask(UUID playerId, String taskName);
+
+    /**
+     * Connects the player to a specific service.
+     *
+     * @param playerId    the player's unique id
+     * @param serviceName the CloudNet service to connect to
+     */
+    void connectToServer(UUID playerId, String serviceName);
+}

--- a/common/src/main/java/net/onelitefeather/titan/common/deliver/TitanServerConnector.java
+++ b/common/src/main/java/net/onelitefeather/titan/common/deliver/TitanServerConnector.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2025 OneLiteFeather Network
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.onelitefeather.titan.common.deliver;
+
+import java.util.UUID;
+
+/**
+ * Cross-classloader bridge for connecting players to other CloudNet services.
+ *
+ * <p>The CloudNet bridge (with its {@code PlayerManager}) runs inside the bridge extension
+ * classloader; the application cannot reference those classes. This holder lives on the shared
+ * application classloader and lets the application request a server switch via JDK types only.
+ * The bridge extension installs the actual {@link ServerConnector}; until then calls are no-ops.
+ */
+public final class TitanServerConnector {
+
+    private static volatile ServerConnector connector;
+
+    private TitanServerConnector() {
+    }
+
+    /**
+     * Installs the connector. Called by the bridge extension once the bridge is up.
+     *
+     * @param serverConnector the connector backed by the CloudNet bridge player manager
+     */
+    public static void setConnector(ServerConnector serverConnector) {
+        connector = serverConnector;
+    }
+
+    /**
+     * Connects the player to the best service of the given task, or does nothing if no connector
+     * has been installed (for example when running standalone).
+     *
+     * @param playerId the player's unique id
+     * @param taskName the CloudNet task to connect to
+     */
+    public static void connectToTask(UUID playerId, String taskName) {
+        ServerConnector current = connector;
+        if (current != null) {
+            current.connectToTask(playerId, taskName);
+        }
+    }
+
+    /**
+     * Connects the player to a specific service, or does nothing if no connector has been
+     * installed.
+     *
+     * @param playerId    the player's unique id
+     * @param serviceName the CloudNet service to connect to
+     */
+    public static void connectToServer(UUID playerId, String serviceName) {
+        ServerConnector current = connector;
+        if (current != null) {
+            current.connectToServer(playerId, serviceName);
+        }
+    }
+}


### PR DESCRIPTION
## Problem
After the bridge loads (Minestom 26.1 build), clicking a navigation item crashed the service:
```
NoClassDefFoundError: eu/cloudnetservice/modules/bridge/player/PlayerManager
  at net.onelitefeather.titan.common.deliver.MessageChannelDeliver.sendPlayer(...)
```
`MessageChannelDeliver` (application realm) referenced the CloudNet bridge `PlayerManager` — same classloader-isolation issue as the permission checker: bridge-api classes live in the bridge extension classloader, not on the application classpath.

## Fix
Same pattern as the permission bridge, reverse direction:
- The player switch now runs in the **`:bridge` extension** (bridge realm, where `PlayerManager`/`PlayerExecutor` are visible). The extension installs a `ServerConnector`.
- The application calls it through the JDK-typed **`TitanServerConnector`** holder. `MessageChannelDeliver` is now CloudNet-free.
- `:common` therefore drops **all** its CloudNet `compileOnly` deps.
- Also fixes the registry lookup name: the bridge registers the service-side `PlayerManager` as `"PlayerManager"` (the old code used `"playerManager"`, which silently returned null).

## Testing
- `:common` compiles with no CloudNet on its classpath; `:bridge:jar` compiles against the real bridge-api/impl (only our class + `extension.json`, 0 leaked classes).
- App fat jar: 0 CloudNet classes; standalone boots cleanly (exit 0, NoopDeliver path).
- ⚠️ The CloudNet-runtime switch (`PlayerExecutor.connect`/`connectToTask`) needs a smoke test on the real network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)