### PR TITLE
fix(lobby): stand up from a seat on sneak, not on backward

### DIFF
--- a/app/src/main/java/net/onelitefeather/titan/app/listener/SitLeavePacketListener.java
+++ b/app/src/main/java/net/onelitefeather/titan/app/listener/SitLeavePacketListener.java
@@ -27,9 +27,12 @@ public final class SitLeavePacketListener implements Consumer<PlayerPacketEvent>
 
     @Override
     public void accept(@NotNull PlayerPacketEvent event) {
-        if (event.getPacket() instanceof ClientInputPacket(byte flags)) {
+        // Stand up (dismount) when the sitting player presses sneak. Use the shift() accessor
+        // rather than testing the raw flags: the sneak bit is 0x20, not 0x02 (that is backward),
+        // and shift() also matches when other movement keys are held at the same time.
+        if (event.getPacket() instanceof ClientInputPacket input && input.shift()) {
             var ridingEntity = event.getPlayer().getVehicle();
-            if (flags == 2 && ridingEntity != null) {
+            if (ridingEntity != null) {
                 var entityDismountEvent = new EntityDismountEvent(event.getPlayer(), ridingEntity);
                 EventDispatcher.call(entityDismountEvent);
             }

--- a/app/src/test/java/net/onelitefeather/titan/app/listener/SitLeavePacketListenerTest.java
+++ b/app/src/test/java/net/onelitefeather/titan/app/listener/SitLeavePacketListenerTest.java
@@ -57,8 +57,9 @@ class SitLeavePacketListenerTest {
         // Register the listener
         MinecraftServer.getGlobalEventHandler().addListener(PlayerPacketEvent.class, listener);
 
-        // Create and call the event with a dismount input packet (flags = 2)
-        ClientInputPacket inputPacket = new ClientInputPacket((byte) 2);
+        // Create and call the event with a sneak (shift) input packet
+        // (forward, backward, left, right, jump, shift, sprint)
+        ClientInputPacket inputPacket = new ClientInputPacket(false, false, false, false, false, true, false);
         PlayerPacketEvent packetEvent = new PlayerPacketEvent(player, inputPacket);
 
         // Use a spy to verify the event is dispatched
@@ -93,8 +94,8 @@ class SitLeavePacketListenerTest {
 
         // Create a mock EventDispatcher to verify the event is not dispatched
         try (var mockedStatic = mockStatic(EventDispatcher.class)) {
-            // Create and call the event with a non-dismount input packet (flags = 1)
-            ClientInputPacket inputPacket = new ClientInputPacket((byte) 1);
+            // Create and call the event with a non-sneak input packet (forward only, no shift)
+            ClientInputPacket inputPacket = new ClientInputPacket(true, false, false, false, false, false, false);
             PlayerPacketEvent packetEvent = new PlayerPacketEvent(player, inputPacket);
             MinecraftServer.getGlobalEventHandler().call(packetEvent);
 
@@ -118,8 +119,8 @@ class SitLeavePacketListenerTest {
 
         // Create a mock EventDispatcher to verify the event is not dispatched
         try (var mockedStatic = mockStatic(EventDispatcher.class)) {
-            // Create and call the event with a dismount input packet (flags = 2)
-            ClientInputPacket inputPacket = new ClientInputPacket((byte) 2);
+            // Create and call the event with a sneak (shift) input packet while not riding
+            ClientInputPacket inputPacket = new ClientInputPacket(false, false, false, false, false, true, false);
             PlayerPacketEvent packetEvent = new PlayerPacketEvent(player, inputPacket);
             MinecraftServer.getGlobalEventHandler().call(packetEvent);
 


### PR DESCRIPTION
## Problem
A sitting player could not stand up by pressing Shift.

`SitLeavePacketListener` dismounted on `ClientInputPacket` `flags == 2`, but in the `ClientInputPacket` bitmask `0x02` is **backward** — the sneak/shift bit is `0x20` (`shift()` = `flags & 32`). So pressing Shift never matched, and the dismount never fired.

## Fix
Use the packet's `shift()` accessor instead of the raw flag value. It is correct regardless of the bit layout and also triggers when other movement keys are held at the same time. Tests updated to the boolean `ClientInputPacket` constructor with the shift flag set.

## Testing
`:app:test --tests *SitLeavePacketListenerTest*` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)