### PR TITLE
feat(app): read the console so CloudNet can stop the service cleanly

### DIFF
--- a/app/src/main/java/net/onelitefeather/titan/app/Titan.java
+++ b/app/src/main/java/net/onelitefeather/titan/app/Titan.java
@@ -27,6 +27,7 @@ import net.minestom.server.instance.InstanceContainer;
 import net.onelitefeather.butterfly.minestom.Butterfly;
 import net.onelitefeather.titan.api.deliver.Deliver;
 import net.onelitefeather.titan.app.commands.EndCommand;
+import net.onelitefeather.titan.app.commands.StopCommand;
 import net.onelitefeather.titan.app.helper.NavigationHelper;
 import net.onelitefeather.titan.app.listener.*;
 import net.onelitefeather.titan.app.player.TitanPlayer;
@@ -74,6 +75,7 @@ public final class Titan {
 
     private void initCommands() {
         MinecraftServer.getCommandManager().register(new EndCommand());
+        MinecraftServer.getCommandManager().register(new StopCommand());
     }
 
     private void initListeners() {

--- a/app/src/main/java/net/onelitefeather/titan/app/TitanApplication.java
+++ b/app/src/main/java/net/onelitefeather/titan/app/TitanApplication.java
@@ -20,11 +20,18 @@ import net.luckperms.api.LuckPermsProvider;
 import net.luckperms.api.model.user.User;
 import net.minestom.server.Auth;
 import net.minestom.server.MinecraftServer;
+import net.minestom.server.command.CommandManager;
 import net.onelitefeather.titan.common.permission.TitanPermissionBridge;
 
+import java.io.BufferedReader;
+import java.io.Console;
+import java.io.IOError;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.function.Supplier;
 
 
 public class TitanApplication {
@@ -60,6 +67,11 @@ public class TitanApplication {
         int bindPort = Integer.getInteger("service.bind.port", 25565);
         bootstrap.start(bindHost, bindPort);
 
+        // Read console input so commands typed locally - and the "stop" command CloudNet writes
+        // to the service's stdin on shutdown - reach the server. Without this the node can only
+        // kill the process after a timeout instead of stopping it cleanly. See StopCommand.
+        startConsole();
+
         // AOT training aid: when -Dtitan.aot.trainSeconds=<n> is set, shut down
         // cleanly after the server has started so the JVM exit writes the AOT
         // configuration/cache. No effect in normal operation.
@@ -74,6 +86,39 @@ public class TitanApplication {
                 System.exit(0);
             });
         }
+    }
+
+    /**
+     * Starts a daemon thread that forwards console input to the command manager's console sender,
+     * so locally typed commands and CloudNet's {@code stop} (written to stdin) are executed.
+     */
+    private static void startConsole() {
+        Supplier<String> lineReader = switch (System.console()) {
+            case Console console -> console::readLine;
+            case null -> {
+                var reader = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
+                yield () -> {
+                    try {
+                        return reader.readLine();
+                    } catch (IOException exception) {
+                        throw new IOError(exception);
+                    }
+                };
+            }
+        };
+
+        CommandManager commandManager = MinecraftServer.getCommandManager();
+        Thread.ofPlatform().name("titan-console").daemon(true).start(() -> {
+            while (MinecraftServer.isStarted()) {
+                String line = lineReader.get();
+                if (line == null) {
+                    break;
+                }
+                if (!line.isBlank()) {
+                    commandManager.execute(commandManager.getConsoleSender(), line.trim());
+                }
+            }
+        });
     }
 
     private static ExtensionBootstrap bootstrap() {

--- a/app/src/main/java/net/onelitefeather/titan/app/commands/StopCommand.java
+++ b/app/src/main/java/net/onelitefeather/titan/app/commands/StopCommand.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2025 OneLiteFeather Network
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.onelitefeather.titan.app.commands;
+
+import net.kyori.adventure.permission.PermissionChecker;
+import net.kyori.adventure.util.TriState;
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.command.CommandSender;
+import net.minestom.server.command.builder.Command;
+import net.minestom.server.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Stops the service cleanly. CloudNet shuts a service down by writing {@code stop} to its console
+ * (see the console reader in {@code TitanApplication}); this command turns that into a clean,
+ * fast {@link MinecraftServer#stopCleanly()} so the node does not have to kill the process after a
+ * timeout.
+ *
+ * <p>The server console (any non-player sender, i.e. CloudNet) may always stop the service.
+ * Players need the {@code titan.command.stop} permission.
+ */
+public final class StopCommand extends Command {
+
+    private static final String PERMISSION = "titan.command.stop";
+
+    public StopCommand() {
+        super("stop");
+        setCondition(this::canStop);
+        // Stop on a separate platform thread so stopCleanly() (which shuts down the server, and
+        // with it the console thread that triggered this) does not run on the caller's thread.
+        setDefaultExecutor((sender, context) -> Thread.ofPlatform().name("titan-stop").start(() -> {
+            MinecraftServer.stopCleanly();
+            System.exit(0);
+        }));
+    }
+
+    private boolean canStop(@NotNull CommandSender sender, @Nullable String commandString) {
+        if (!(sender instanceof Player)) {
+            return true;
+        }
+        return sender.getOrDefault(PermissionChecker.POINTER, PermissionChecker.always(TriState.FALSE)).test(PERMISSION);
+    }
+}


### PR DESCRIPTION
## Why
CloudNet shuts a service down by writing `stop` (and `end`) to its stdin and waiting for the process to exit; only if it does not exit in time does the node kill it. Minestom ships no console reader, so that input was never read — every Titan service was hard-killed after the timeout (slow, unclean).

## What
- **Console reader** (`TitanApplication#startConsole`): a daemon thread that forwards stdin (or `System.console()`) to `commandManager.getConsoleSender()`, so locally typed commands and CloudNet's `stop` are executed. Pattern adapted from 0utplay's `MinestomServer`.
- **`StopCommand` (`stop`)**: calls `MinecraftServer.stopCleanly()` on a platform thread (so it does not run on the console thread it tears down) then `System.exit(0)` — clean and fast.
- **Permissions**: the server console (any non-player sender, i.e. CloudNet) may always stop; players require `titan.command.stop`, checked via the Adventure `PermissionChecker` pointer (LuckPerms-backed). Players without it cannot stop the lobby.

## Testing
Built; booting the fat jar and feeding `stop` to stdin exits cleanly (exit 0) instead of hitting the timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)