### PR TITLE
ci: pin the pipeline JDK to Temurin 25.0.3 LTS

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -4,4 +4,8 @@ on: [pull_request]
 jobs:
   build:
     uses: OneLiteFeatherNET/workflows/.github/workflows/gradle-build-pr.yml@v2.1.0
+    # Match the runtime LTS JDK (Temurin 25.0.3) used by the publish pipeline.
+    with:
+      java-version: "25.0.3"
+      java-distribution: "temurin"
     secrets: inherit

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,4 +10,10 @@ on:
 jobs:
   publish:
     uses: OneLiteFeatherNET/workflows/.github/workflows/gradle-publish.yml@v2.1.0
+    # Pin the exact LTS JDK the lobby runs on: the published AOT cache is tied to
+    # the precise HotSpot build, so it must be generated with the runtime's JDK
+    # (Temurin 25.0.3 LTS) or the service fails with "Unable to map shared spaces".
+    with:
+      java-version: "25.0.3"
+      java-distribution: "temurin"
     secrets: inherit

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -28,4 +28,10 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     uses: OneLiteFeatherNET/workflows/.github/workflows/gradle-publish.yml@v2.1.0
+    # Pin the exact LTS JDK the lobby runs on: the published AOT cache is tied to
+    # the precise HotSpot build, so it must be generated with the runtime's JDK
+    # (Temurin 25.0.3 LTS) or the service fails with "Unable to map shared spaces".
+    with:
+      java-version: "25.0.3"
+      java-distribution: "temurin"
     secrets: inherit


### PR DESCRIPTION
## Why
The published AOT cache (`app-titan.aot`) is tied to the **exact** HotSpot build that created it. The lobby service runs **Temurin 25.0.3+9-LTS**, but the cache shipped was built with 25.0.2, so on startup the JVM logged:
```
[warning][aot] The AOT cache was created by a different version or build of HotSpot
[error][aot] Loading static archive failed.
[error][aot] Unable to map shared spaces
```
and the lobby started without AOT (slower).

## Change
Pin the reusable build/publish workflows to the runtime's exact LTS patch via their `java-version` / `java-distribution` inputs:
- `publish.yaml` (tag publish) and the chained `publish` job in `release-please.yaml` — these generate the AOT cache artifact.
- `build-pr.yml` — for parity.

So the next published `app-titan.aot` is generated with the same JDK the service runs, and maps cleanly.

## Note
AOT caches are inherently JDK-build-specific: if the runtime JDK is later bumped (e.g. 25.0.4), this pin must move with it. Keep the pipeline JDK and the CloudNet service JDK in lock-step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)