### PR TITLE
feat(lobby): make the elytra firework boost vanilla-accurate

### DIFF
--- a/app/src/main/java/net/onelitefeather/titan/app/listener/ElytraBoostListener.java
+++ b/app/src/main/java/net/onelitefeather/titan/app/listener/ElytraBoostListener.java
@@ -15,18 +15,45 @@
  */
 package net.onelitefeather.titan.app.listener;
 
+import net.minestom.server.ServerFlag;
+import net.minestom.server.component.DataComponents;
 import net.minestom.server.coordinate.Vec;
+import net.minestom.server.entity.Player;
 import net.minestom.server.event.player.PlayerUseItemEvent;
+import net.minestom.server.item.ItemStack;
+import net.minestom.server.item.component.FireworkList;
+import net.minestom.server.timer.TaskSchedule;
 import net.onelitefeather.titan.common.config.AppConfig;
 import net.onelitefeather.titan.common.utils.Items;
 
+import java.util.Map;
 import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
+/**
+ * Recreates the vanilla elytra firework boost.
+ *
+ * <p>In vanilla, a used firework rocket attaches to the gliding player and, every tick for its
+ * lifetime, nudges the player's velocity towards {@code look * 1.5}
+ * (see {@code net.minecraft.world.entity.projectile.FireworkRocketEntity#tick}). Minestom does not
+ * implement firework items, so this listener reproduces that behaviour: it runs a per-tick task on
+ * the player's scheduler that applies the same formula for the same vanilla lifetime.
+ *
+ * <p>Velocity is computed in vanilla per-tick units and converted to Minestom's per-second velocity
+ * on apply. {@link AppConfig#elytraBoostMultiplier()} scales the output ({@code 1.0} = vanilla).
+ */
 public final class ElytraBoostListener implements Consumer<PlayerUseItemEvent> {
+
+    // Constants from FireworkRocketEntity#tick (per-tick deltaMovement units).
+    private static final double LOOK_ACCELERATION = 0.1;
+    private static final double LOOK_TARGET = 1.5;
+    private static final double PULL_TOWARDS_TARGET = 0.5;
 
     private final AppConfig appConfig;
     private final Random random = new Random();
+    private final Map<UUID, Boost> boosts = new ConcurrentHashMap<>();
 
     public ElytraBoostListener(AppConfig appConfig) {
         this.appConfig = appConfig;
@@ -34,41 +61,54 @@ public final class ElytraBoostListener implements Consumer<PlayerUseItemEvent> {
 
     @Override
     public void accept(PlayerUseItemEvent event) {
-        var itemStack = event.getItemStack();
-        if (itemStack.isSimilar(Items.PLAYER_FIREWORK) && event.getPlayer().isFlyingWithElytra()) {
-            // In vanilla Minecraft, firework power affects boost strength
-            // Since we don't have power levels in our firework, we'll use the config
-            // multiplier
-            // as a base and implement the vanilla-like boost logic
+        Player player = event.getPlayer();
+        if (!player.isFlyingWithElytra() || !event.getItemStack().isSimilar(Items.PLAYER_FIREWORK)) {
+            return;
+        }
 
-            // Get player's current direction and velocity
-            Vec playerDirection = event.getPlayer().getPosition().direction();
-            Vec playerVelocity = event.getPlayer().getVelocity();
+        // Vanilla: lifetime = 10 * flightCount + random(6) + random(7), flightCount = 1 + flight duration.
+        int lifetime = 10 * flightCount(event.getItemStack()) + this.random.nextInt(6) + this.random.nextInt(7);
 
-            // Calculate the boost vector based on vanilla Minecraft mechanics
-            // 1. Add a boost in the player's looking direction
-            double baseBoost = this.appConfig.elytraBoostMultiplier();
-            Vec boostVector = playerDirection.mul(baseBoost);
+        Boost active = this.boosts.get(player.getUuid());
+        if (active != null) {
+            // Using a rocket during an active boost extends it, as stacking rockets does in vanilla.
+            active.remainingTicks = Math.max(active.remainingTicks, lifetime);
+            return;
+        }
 
-            // 2. Add a small random component for natural movement (vanilla-like)
-            double randomX = (random.nextDouble() - 0.5) * 0.05;
-            double randomY = (random.nextDouble() - 0.5) * 0.05;
-            double randomZ = (random.nextDouble() - 0.5) * 0.05;
-            Vec randomComponent = new Vec(randomX, randomY, randomZ);
+        Boost boost = new Boost(player.getVelocity().div(ServerFlag.SERVER_TICKS_PER_SECOND), lifetime);
+        this.boosts.put(player.getUuid(), boost);
+        player.scheduler().submitTask(() -> tick(player, boost));
+    }
 
-            // 3. Apply the boost
-            // In vanilla, if player is looking down, boost has more upward component
-            if (playerDirection.y() < 0) {
-                // Add a slight upward boost when looking down to prevent crashing
-                double upwardCorrection = -playerDirection.y() * 0.3;
-                boostVector = boostVector.add(0, upwardCorrection, 0);
-            }
+    private TaskSchedule tick(Player player, Boost boost) {
+        if (!player.isOnline() || !player.isFlyingWithElytra() || boost.remainingTicks-- <= 0) {
+            this.boosts.remove(player.getUuid());
+            return TaskSchedule.stop();
+        }
 
-            // Combine all components and apply to player
-            Vec finalVelocity = playerVelocity.add(boostVector).add(randomComponent);
+        Vec look = player.getPosition().direction();
+        Vec velocity = boost.velocity;
+        Vec next = velocity.add(
+                look.x() * LOOK_ACCELERATION + (look.x() * LOOK_TARGET - velocity.x()) * PULL_TOWARDS_TARGET, look.y() * LOOK_ACCELERATION + (look.y() * LOOK_TARGET - velocity.y()) * PULL_TOWARDS_TARGET, look.z() * LOOK_ACCELERATION + (look.z() * LOOK_TARGET - velocity.z()) * PULL_TOWARDS_TARGET);
+        boost.velocity = next;
+        player.setVelocity(next.mul(ServerFlag.SERVER_TICKS_PER_SECOND * this.appConfig.elytraBoostMultiplier()));
+        return TaskSchedule.tick(1);
+    }
 
-            // Apply the velocity
-            event.getPlayer().setVelocity(finalVelocity);
+    private int flightCount(ItemStack itemStack) {
+        FireworkList fireworks = itemStack.get(DataComponents.FIREWORKS);
+        return fireworks != null ? 1 + fireworks.flightDuration() : 1;
+    }
+
+    private static final class Boost {
+
+        private Vec velocity;
+        private int remainingTicks;
+
+        private Boost(Vec velocity, int remainingTicks) {
+            this.velocity = velocity;
+            this.remainingTicks = remainingTicks;
         }
     }
 }

--- a/app/src/test/java/net/onelitefeather/titan/app/listener/ElytraBoostListenerTest.java
+++ b/app/src/test/java/net/onelitefeather/titan/app/listener/ElytraBoostListenerTest.java
@@ -16,6 +16,7 @@
 package net.onelitefeather.titan.app.listener;
 
 import net.minestom.server.MinecraftServer;
+import net.minestom.server.ServerFlag;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.Player;
@@ -123,32 +124,32 @@ class ElytraBoostListenerTest {
         // Verify that setVelocity was called and capture the value
         verify(player).setVelocity(velocityCaptor.capture());
 
-        // Get the captured velocity
+        // Get the captured velocity (the first vanilla boost tick, applied synchronously)
         Vec capturedVelocity = velocityCaptor.getValue();
 
-        // Calculate the expected velocity
-        // Initial velocity + (direction * boostMultiplier) + random component
-        // Since we can't predict the random component exactly, we'll check if the
-        // velocity is in the expected range
+        // The first-tick boost is deterministic (randomness only affects the lifetime).
+        Vec expected = expectedFirstTick(initialVelocity, playerPos.direction(), boostMultiplier);
+        double tolerance = 1.0E-6;
 
-        // The direction vector when looking straight ahead (pitch=0, yaw=0) is (0, 0,
-        // 1)
-        Vec expectedDirectionBoost = new Vec(0, 0, boostMultiplier);
-
-        // Expected velocity without random component
-        Vec expectedBaseVelocity = initialVelocity.add(expectedDirectionBoost);
-
-        // Check if the captured velocity is close to the expected velocity (allowing
-        // for the random component)
-        double tolerance = 0.1; // Tolerance for the random component
-
-        // Check each component
-        assertTrue(Math.abs(capturedVelocity.x() - expectedBaseVelocity.x()) <= tolerance, "X component of velocity should be within tolerance of expected value");
-        assertTrue(Math.abs(capturedVelocity.y() - expectedBaseVelocity.y()) <= tolerance, "Y component of velocity should be within tolerance of expected value");
-        assertTrue(Math.abs(capturedVelocity.z() - expectedBaseVelocity.z()) <= tolerance, "Z component of velocity should be within tolerance of expected value");
+        assertTrue(Math.abs(capturedVelocity.x() - expected.x()) <= tolerance, "X component of velocity should match the vanilla first-tick boost");
+        assertTrue(Math.abs(capturedVelocity.y() - expected.y()) <= tolerance, "Y component of velocity should match the vanilla first-tick boost");
+        assertTrue(Math.abs(capturedVelocity.z() - expected.z()) <= tolerance, "Z component of velocity should match the vanilla first-tick boost");
     }
 
-    @DisplayName("Test the random component of the boost")
+    /**
+     * Replicates the first-tick velocity the listener applies: the vanilla per-tick formula
+     * {@code vel += look*0.1 + (look*1.5 - vel)*0.5} seeded from the current velocity, converted
+     * back to Minestom's per-second velocity and scaled by the boost multiplier.
+     */
+    private static Vec expectedFirstTick(Vec currentVelocity, Vec look, double multiplier) {
+        double tps = ServerFlag.SERVER_TICKS_PER_SECOND;
+        Vec velocity = currentVelocity.div(tps);
+        Vec next = velocity.add(
+                look.x() * 0.1 + (look.x() * 1.5 - velocity.x()) * 0.5, look.y() * 0.1 + (look.y() * 1.5 - velocity.y()) * 0.5, look.z() * 0.1 + (look.z() * 1.5 - velocity.z()) * 0.5);
+        return next.mul(tps * multiplier);
+    }
+
+    @DisplayName("Test the boost applies a velocity with the default config")
     @Test
     void testRandomComponent(Env env) {
         // Create the listener with the default config
@@ -171,7 +172,7 @@ class ElytraBoostListenerTest {
         verify(player).setVelocity(any(Vec.class));
     }
 
-    @DisplayName("Test the upward correction when looking down")
+    @DisplayName("Test the boost accelerates along the look direction when looking down")
     @Test
     void testUpwardCorrectionWhenLookingDown(Env env) {
         // Create a custom AppConfig with a specific boost multiplier
@@ -202,15 +203,11 @@ class ElytraBoostListenerTest {
 
         playerUseItemEventCollector.assertSingle();
 
-        Vec playerDirection = player.getPosition().direction();
-        Vec boost = playerDirection.mul(boostMultiplier);
-        if (playerDirection.y() < 0) {
-            boost = boost.add(0, -playerDirection.y() * 0.3, 0);
-        }
-        Vec expected = initialVelocity.add(boost);
-
+        // The boost points along the look direction (here: straight down), with no special
+        // "looking down" correction - just the vanilla first-tick acceleration.
+        Vec expected = expectedFirstTick(initialVelocity, player.getPosition().direction(), boostMultiplier);
         Vec actual = player.getVelocity();
-        double tolerance = 0.1;
+        double tolerance = 1.0E-3;
 
         assertTrue(Math.abs(actual.x() - expected.x()) <= tolerance);
         assertTrue(Math.abs(actual.y() - expected.y()) <= tolerance);


### PR DESCRIPTION
## What
Rebuilds the elytra firework boost to match vanilla almost 1:1.

The previous `ElytraBoostListener` applied a **single** instantaneous impulse (`look * multiplier`) plus random jitter and an ad-hoc "looking down" correction — it didn't feel like vanilla.

Vanilla (`net.minecraft.world.entity.projectile.FireworkRocketEntity#tick`) instead applies a **sustained** boost: while the rocket is attached to the gliding player, every tick for its lifetime it nudges the player's velocity towards `look * 1.5`:
```
vel += look*0.1 + (look*1.5 - vel)*0.5
```
for `lifetime = 10 * flightCount + random(6) + random(7)` ticks (`flightCount = 1 + flight_duration`).

## How
- On `PlayerUseItemEvent`, if the player is gliding (`isFlyingWithElytra`) and the item is the lobby firework, start a per-tick task on the player's scheduler that applies the exact formula for the vanilla lifetime.
- Velocity is tracked in vanilla per-tick units and converted to Minestom's per-second velocity on apply (`* SERVER_TICKS_PER_SECOND`). `elytraBoostMultiplier` scales the output (`1.0` = vanilla).
- Reusing a rocket mid-boost extends it (vanilla rockets stack); the boost ends on lifetime expiry or when the player stops gliding / disconnects. Gliding itself is handled by Minestom + the existing start/stop listeners (firework given in the offhand while gliding).

## Testing
Builds; standalone boots. ⚠️ The in-flight feel needs a play test on the server (player velocity is client-authoritative in Minestom, so the boost is applied via velocity packets rather than server-simulated movement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)