### PR TITLE
build: extract shared Gradle logic into buildSrc conventions

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,7 +1,8 @@
 plugins {
-    java
+    id("titan.java-conventions")
     `java-library`
 }
+
 dependencies {
     implementation(platform(libs.aonyx.bom))
     api(libs.minestom)
@@ -10,15 +11,4 @@ dependencies {
     testImplementation(libs.junit.api)
     testImplementation(libs.junit.platform.launcher)
     testRuntimeOnly(libs.junit.engine)
-}
-
-tasks.test {
-    useJUnitPlatform()
-    jvmArgs("-Dminestom.inside-test=true")
-}
-
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(25))
-    }
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,10 +1,10 @@
 import java.nio.file.Files
 
 plugins {
-    java
+    id("titan.java-conventions")
+    id("titan.publish-conventions")
+    id("com.gradleup.shadow")
     application
-    id("com.gradleup.shadow") version "9.6.1"
-    `maven-publish`
 }
 
 dependencies {
@@ -61,14 +61,9 @@ dependencies {
 configurations.testRuntimeClasspath {
     exclude(group = "net.luckperms", module = "minestom-loader")
 }
+
 application {
     mainClass.set("net.onelitefeather.titan.app.TitanApplication")
-}
-
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(25))
-    }
 }
 
 tasks {
@@ -87,10 +82,6 @@ tasks {
         exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA")
         exclude("module-info.class", "META-INF/versions/**/module-info.class")
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    }
-    test {
-        useJUnitPlatform()
-        jvmArgs("-Dminestom.inside-test=true")
     }
 }
 
@@ -139,57 +130,18 @@ val generateAotCache = tasks.register<Exec>("generateAotCache") {
         )
     }
 }
-publishing {
-    publications.create<MavenPublication>("maven") {
-        artifact(project.tasks.getByName("shadowJar"))
-        // AOT cache shipped alongside the jar for faster startup; see generateAotCache.
-        artifact(aotCacheFile) {
-            classifier = "aot"
-            extension = "aot"
-            builtBy(generateAotCache)
-        }
-        version = rootProject.version as String
-        artifactId = "titan-app"
-        groupId = rootProject.group as String
-        pom {
-            name = "Titan App"
-            description = "Titan App Server for OneLiteFeather"
-            url = "https://github.com/OneLiteFeatherNET/titan"
-            licenses {
-                license {
-                    name = "The Apache License, Version 2.0"
-                    url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
-                }
-            }
-            developers {
-                developer {
-                    id = "themeinerlp"
-                    name = "Phillipp Glanz"
-                    email = "p.glanz@madfix.me"
-                }
-            }
-            scm {
-                connection = "scm:git:git://github.com:OneLiteFeatherNET/Titan.git"
-                developerConnection = "scm:git:ssh://git@github.com:OneLiteFeatherNET/Titan.git"
-                url = "https://github.com/OneLiteFeatherNET/titan"
-            }
-        }
+
+publishing.publications.named<MavenPublication>("maven") {
+    artifactId = "titan-app"
+    artifact(tasks.shadowJar)
+    // AOT cache shipped alongside the jar for faster startup; see generateAotCache.
+    artifact(aotCacheFile) {
+        classifier = "aot"
+        extension = "aot"
+        builtBy(generateAotCache)
     }
-
-    repositories {
-        maven {
-            authentication {
-                credentials(PasswordCredentials::class) {
-                    // Those credentials need to be set under "Settings -> Secrets -> Actions" in your repository
-                    username = System.getenv("ONELITEFEATHER_MAVEN_USERNAME")
-                    password = System.getenv("ONELITEFEATHER_MAVEN_PASSWORD")
-                }
-            }
-
-            name = "OneLiteFeatherRepository"
-            val releasesRepoUrl = uri("https://repo.onelitefeather.dev/onelitefeather-releases")
-            val snapshotsRepoUrl = uri("https://repo.onelitefeather.dev/onelitefeather-snapshots")
-            url = if (version.toString().contains("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
-        }
+    pom {
+        name = "Titan App"
+        description = "Titan App Server for OneLiteFeather"
     }
 }

--- a/bridge/build.gradle.kts
+++ b/bridge/build.gradle.kts
@@ -1,8 +1,8 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
-    java
-    `maven-publish`
+    id("titan.java-conventions")
+    id("titan.publish-conventions")
 }
 
 // Minestom extension that bridges CloudNet permission checks to LuckPerms. It is
@@ -23,12 +23,6 @@ dependencies {
     compileOnly(libs.cloudnet.bridge.impl)
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(25))
-    }
-}
-
 // Stamp the project version into extension.json (@version@ placeholder).
 tasks.processResources {
     val tokens = mapOf("version" to project.version.toString())
@@ -38,50 +32,11 @@ tasks.processResources {
     }
 }
 
-publishing {
-    publications.create<MavenPublication>("maven") {
-        artifact(tasks.named("jar"))
-        version = rootProject.version as String
-        artifactId = "titan-bridge"
-        groupId = rootProject.group as String
-        pom {
-            name = "Titan Bridge"
-            description = "CloudNet bridge extension that resolves permissions through LuckPerms"
-            url = "https://github.com/OneLiteFeatherNET/titan"
-            licenses {
-                license {
-                    name = "The Apache License, Version 2.0"
-                    url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
-                }
-            }
-            developers {
-                developer {
-                    id = "themeinerlp"
-                    name = "Phillipp Glanz"
-                    email = "p.glanz@madfix.me"
-                }
-            }
-            scm {
-                connection = "scm:git:git://github.com:OneLiteFeatherNET/Titan.git"
-                developerConnection = "scm:git:ssh://git@github.com:OneLiteFeatherNET/Titan.git"
-                url = "https://github.com/OneLiteFeatherNET/titan"
-            }
-        }
-    }
-
-    repositories {
-        maven {
-            authentication {
-                credentials(PasswordCredentials::class) {
-                    username = System.getenv("ONELITEFEATHER_MAVEN_USERNAME")
-                    password = System.getenv("ONELITEFEATHER_MAVEN_PASSWORD")
-                }
-            }
-
-            name = "OneLiteFeatherRepository"
-            val releasesRepoUrl = uri("https://repo.onelitefeather.dev/onelitefeather-releases")
-            val snapshotsRepoUrl = uri("https://repo.onelitefeather.dev/onelitefeather-snapshots")
-            url = if (version.toString().contains("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
-        }
+publishing.publications.named<MavenPublication>("maven") {
+    artifactId = "titan-bridge"
+    artifact(tasks.named("jar"))
+    pom {
+        name = "Titan Bridge"
+        description = "CloudNet bridge extension that resolves permissions through LuckPerms"
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,8 @@ import com.diffplug.gradle.spotless.SpotlessExtension
 
 plugins {
     id("com.diffplug.spotless") version "8.10.1" apply false
+    // Declared once here so :app and :setup can apply it without repeating the version.
+    id("com.gradleup.shadow") version "9.6.1" apply false
 }
 
 // gradle.properties carries the release-please annotation inline

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+}

--- a/buildSrc/src/main/kotlin/titan.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/titan.java-conventions.gradle.kts
@@ -1,0 +1,38 @@
+// Shared Java setup for every Titan module. Previously this block was copied into
+// each module build file: the toolchain five times, the test configuration four
+// times, and Jacoco into only two of the five modules.
+
+plugins {
+    java
+    jacoco
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(25))
+    }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.release.set(25)
+    options.encoding = "UTF-8"
+    options.compilerArgs.addAll(listOf("-Xlint:deprecation", "-Xlint:unchecked"))
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+    // Minestom refuses to initialise its registries outside a real server process
+    // unless this flag is set.
+    jvmArgs("-Dminestom.inside-test=true")
+    finalizedBy(tasks.matching { it.name == "jacocoTestReport" })
+    testLogging {
+        events("passed", "skipped", "failed")
+    }
+}
+
+tasks.withType<JacocoReport>().configureEach {
+    dependsOn(tasks.matching { it.name == "test" })
+    reports {
+        xml.required.set(true)
+    }
+}

--- a/buildSrc/src/main/kotlin/titan.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/titan.publish-conventions.gradle.kts
@@ -1,0 +1,64 @@
+// Shared publishing setup for the three published Titan modules (:app, :setup,
+// :bridge). Coordinates, licence, developer, SCM and the target repository are
+// identical everywhere; only artifactId, POM name, POM description and the
+// published artifacts differ, so those stay in the module build files:
+//
+//   publishing.publications.named<MavenPublication>("maven") {
+//       artifactId = "titan-<module>"
+//       artifact(tasks.shadowJar)
+//       pom {
+//           name = "..."
+//           description = "..."
+//       }
+//   }
+
+plugins {
+    `maven-publish`
+}
+
+publishing {
+    publications.create<MavenPublication>("maven") {
+        groupId = rootProject.group.toString()
+        version = rootProject.version.toString()
+
+        pom {
+            url = "https://github.com/OneLiteFeatherNET/titan"
+            licenses {
+                license {
+                    name = "The Apache License, Version 2.0"
+                    url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                }
+            }
+            developers {
+                developer {
+                    id = "themeinerlp"
+                    name = "Phillipp Glanz"
+                    email = "p.glanz@madfix.me"
+                }
+            }
+            scm {
+                connection = "scm:git:git://github.com:OneLiteFeatherNET/Titan.git"
+                developerConnection = "scm:git:ssh://git@github.com:OneLiteFeatherNET/Titan.git"
+                url = "https://github.com/OneLiteFeatherNET/titan"
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = "OneLiteFeatherRepository"
+            authentication {
+                credentials(PasswordCredentials::class) {
+                    // Those credentials need to be set under "Settings -> Secrets -> Actions" in your repository
+                    username = System.getenv("ONELITEFEATHER_MAVEN_USERNAME")
+                    password = System.getenv("ONELITEFEATHER_MAVEN_PASSWORD")
+                }
+            }
+            url = if (rootProject.version.toString().contains("SNAPSHOT")) {
+                uri("https://repo.onelitefeather.dev/onelitefeather-snapshots")
+            } else {
+                uri("https://repo.onelitefeather.dev/onelitefeather-releases")
+            }
+        }
+    }
+}

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
-   java
-    jacoco
+    id("titan.java-conventions")
 }
 
 dependencies {
@@ -22,17 +21,4 @@ dependencies {
     testImplementation(libs.junit.api)
     testImplementation(libs.junit.platform.launcher)
     testRuntimeOnly(libs.junit.engine)
-}
-
-tasks {
-    test {
-        useJUnitPlatform()
-        jvmArgs("-Dminestom.inside-test=true")
-    }
-}
-
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(25))
-    }
 }

--- a/setup/build.gradle.kts
+++ b/setup/build.gradle.kts
@@ -1,9 +1,8 @@
 plugins {
-    java
+    id("titan.java-conventions")
+    id("titan.publish-conventions")
+    id("com.gradleup.shadow")
     application
-    `maven-publish`
-    id("com.gradleup.shadow") version "9.6.1"
-    jacoco
 }
 
 dependencies {
@@ -21,15 +20,10 @@ dependencies {
     testImplementation(libs.junit.platform.launcher)
     testRuntimeOnly(libs.junit.engine)
 }
+
 application {
     mainClass.set("net.onelitefeather.titan.setup.TitanLauncher")
     applicationDefaultJvmArgs = listOf("-DTITAN_LOBBY_MAP=halloween")
-}
-
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(25))
-    }
 }
 
 tasks {
@@ -44,57 +38,13 @@ tasks {
         archiveFileName.set("setup-titan.jar")
         mergeServiceFiles()
     }
-    test {
-        useJUnitPlatform()
-        jvmArgs("-Dminestom.inside-test=true")
-    }
 }
 
-publishing {
-    publications.create<MavenPublication>("maven") {
-        artifact(project.tasks.getByName("shadowJar"))
-        version = rootProject.version as String
-        artifactId = "titan-setup"
-        groupId = rootProject.group as String
-        pom {
-            name = "Titan Setup"
-            description = "Titan Setup Server for OneLiteFeather"
-            url = "https://github.com/OneLiteFeatherNET/titan"
-            licenses {
-                license {
-                    name = "The Apache License, Version 2.0"
-                    url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
-                }
-            }
-            developers {
-                developer {
-                    id = "themeinerlp"
-                    name = "Phillipp Glanz"
-                    email = "p.glanz@madfix.me"
-                }
-            }
-            scm {
-                connection = "scm:git:git://github.com:OneLiteFeatherNET/Titan.git"
-                developerConnection = "scm:git:ssh://git@github.com:OneLiteFeatherNET/Titan.git"
-                url = "https://github.com/OneLiteFeatherNET/titan"
-            }
-        }
-    }
-
-    repositories {
-        maven {
-            authentication {
-                credentials(PasswordCredentials::class) {
-                    // Those credentials need to be set under "Settings -> Secrets -> Actions" in your repository
-                    username = System.getenv("ONELITEFEATHER_MAVEN_USERNAME")
-                    password = System.getenv("ONELITEFEATHER_MAVEN_PASSWORD")
-                }
-            }
-
-            name = "OneLiteFeatherRepository"
-            val releasesRepoUrl = uri("https://repo.onelitefeather.dev/onelitefeather-releases")
-            val snapshotsRepoUrl = uri("https://repo.onelitefeather.dev/onelitefeather-snapshots")
-            url = if (version.toString().contains("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
-        }
+publishing.publications.named<MavenPublication>("maven") {
+    artifactId = "titan-setup"
+    artifact(tasks.shadowJar)
+    pom {
+        name = "Titan Setup"
+        description = "Titan Setup Server for OneLiteFeather"
     }
 }


### PR DESCRIPTION
## Warum

Die Build-Logik war über die Modul-Buildfiles hinweg kopiert statt geteilt:

| Duplikat | vorher | nachher |
|---|---|---|
| `java { toolchain { …25 } }` | 5× | 1× |
| Test-Konfiguration (`useJUnitPlatform`, `-Dminestom.inside-test=true`) | 4× | 1× |
| Publishing-Boilerplate (Lizenz, Developer, SCM, Repository, ~45 Zeilen) | 3× | 1× |
| Shadow-Version `9.6.1` hartcodiert | 2× | 1× (Root, `apply false`) |
| Jacoco | nur `:common` + `:setup` | alle Module |

`:app` hatte 15 Testklassen, aber **keinen** Coverage-Report, weil Jacoco dort nie angewendet wurde.

## Was

Zwei precompiled script plugins in `buildSrc`:

- **`titan.java-conventions`** — Toolchain 25, javac-Optionen (`--release 25`, UTF-8, `-Xlint:deprecation,unchecked`), JUnit-Platform mit `minestom.inside-test`, Jacoco mit XML-Report an `test` gekoppelt
- **`titan.publish-conventions`** — die `maven`-Publication mit Koordinaten, POM-Metadaten und dem OneLiteFeather-Repository

In den Modulen bleibt nur, was sich tatsächlich unterscheidet — `artifactId`, POM-`name`/`description` und die publizierten Artefakte:

```kotlin
publishing.publications.named<MavenPublication>("maven") {
    artifactId = "titan-app"
    artifact(tasks.shadowJar)
    pom {
        name = "Titan App"
        description = "Titan App Server for OneLiteFeather"
    }
}
```

Unterm Strich: −207 / +151 Zeilen, 245 Zeilen dupliziertes Modul-Boilerplate ersetzt durch 109 Zeilen geteilte Conventions.

Damit erfüllt Titan **OLF-L1-01** aus dem OLF-Minestom-Project-Standard und zieht mit Cygnus' `cygnus.java-conventions` gleich.

## Verifikation — keine Änderung am Build-Output

Gegen einen Baseline-Build von `main` vor der Änderung geprüft:

- ✅ **Alle 7 Jars inhaltsgleich** (sortierte Entry-Listen): `api`, `common`, `bridge`, `app-titan.jar`, `setup-titan.jar`, beide `-unshaded`
- ✅ **Generierte POMs identisch** für `:app`, `:setup`, `:bridge`
- ✅ **Publish-Tasks identisch** (inkl. `publishMavenPublicationToOneLiteFeatherRepositoryRepository`)
- ✅ **Testergebnisse identisch**: 21 Klassen, 56 Tests, 0 Fehler
- ✅ **Abhängigkeitsgraph identisch** bis auf die neuen `jacocoAgent`/`jacocoAnt`-Konfigurationen in `:app`, `:api`, `:bridge` — reine Tooling-Konfigurationen, die auf keinem Compile- oder Runtime-Classpath landen (bestätigt durch die identischen Jars)

## Nebeneffekt

`-Xlint:deprecation` legt fünf bereits vorhandene Warnungen offen:

```
common/.../map/MapProvider.java:48,63    GsonFileHandler ist veraltet (Aves, forRemoval)
common/.../map/MapProvider.java:93       AnvilLoader(Path) ist veraltet (forRemoval)
common/.../config/AppConfigProvider.java:34,41  GsonFileHandler ist veraltet
```

Bewusst als Warnung stehen gelassen — der Wechsel auf `ModernGsonFileHandler` ist eigene Arbeit (Phase 3 des Standards).

## Nicht Teil dieses PRs

- Version bleibt in `gradle.properties` samt `substringBefore('#')`-Hack. Der Umzug nach `build.gradle.kts` (wie in Cygnus) berührt `release-please-config.json` und gehört in einen eigenen PR.
- `shadowJar`-Konfiguration bleibt pro Modul: `:app` setzt Signatur-/`module-info`-Excludes und `DuplicatesStrategy.EXCLUDE`, `:setup` nicht. Vereinheitlichen würde den Output verändern und ist damit kein reines Refactoring.
- Spotless bleibt im `subprojects {}`-Block des Root-Builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtbnMbAj6m2q3vrDYFizDr
