### PR TITLE
feat: deliver a base plus season resource pack stack (Stage 6)

### DIFF
--- a/app/src/main/java/net/onelitefeather/titan/app/Titan.java
+++ b/app/src/main/java/net/onelitefeather/titan/app/Titan.java
@@ -37,6 +37,9 @@ import net.onelitefeather.titan.common.deliver.DeliverProvider;
 import net.onelitefeather.titan.common.event.EntityDismountEvent;
 import net.onelitefeather.titan.common.helper.BlockHandlerHelper;
 import net.onelitefeather.titan.common.map.MapProvider;
+import net.onelitefeather.titan.common.resourcepack.ResourcePackService;
+import net.onelitefeather.titan.common.resourcepack.ResourcePackSettings;
+import net.onelitefeather.titan.common.resourcepack.ResourcePackSettingsProvider;
 import net.onelitefeather.titan.common.utils.Cancelable;
 
 import java.nio.file.Path;
@@ -49,6 +52,7 @@ public final class Titan {
     private final MapProvider mapProvider;
     private final AppConfigProvider appConfigProvider;
     private final NavigationHelper navigationHelper;
+    private final ResourcePackService resourcePackService;
 
     public Titan() {
         MinecraftServer.getConnectionManager().setPlayerProvider(TitanPlayer::new);
@@ -59,6 +63,10 @@ public final class Titan {
         this.mapProvider = MapProvider.create(this.path, instance);
         this.appConfigProvider = AppConfigProvider.create(this.path);
         this.navigationHelper = NavigationHelper.instance(this.deliver);
+        // Without a resource-packs.json this stays disabled and no listener is registered
+        // below, so a lobby without a pack server behaves exactly as it did before.
+        ResourcePackSettings resourcePackSettings = ResourcePackSettingsProvider.load(this.path);
+        this.resourcePackService = ResourcePackService.create(resourcePackSettings);
     }
 
     public void initialize() {
@@ -71,7 +79,7 @@ public final class Titan {
     }
 
     public void terminate() {
-
+        this.resourcePackService.close();
     }
 
     private void initCommands() {
@@ -109,7 +117,32 @@ public final class Titan {
         this.eventNode.addListener(PlayerSpawnEvent.class, new PlayerSpawnListener(
                 this.appConfigProvider.getAppConfig(), this.mapProvider.getActiveLobby(), this.navigationHelper));
 
+        initResourcePackListeners();
+
         MinecraftServer.getGlobalEventHandler().addChild(eventNode);
+    }
+
+    /**
+     * Registers the resource pack listeners - but only when a pack is actually configured. An
+     * unconfigured lobby registers nothing at all and therefore cannot send a single pack packet.
+     */
+    private void initResourcePackListeners() {
+        if (!this.resourcePackService.enabled()) {
+            return;
+        }
+        this.eventNode.addListener(AsyncPlayerConfigurationEvent.class, new ResourcePackConfigurationListener(this.resourcePackService));
+        this.eventNode.addListener(PlayerResourcePackStatusEvent.class, new ResourcePackStatusListener(this.resourcePackService));
+        this.eventNode.addListener(PlayerDisconnectEvent.class, new ResourcePackDisconnectListener(this.resourcePackService));
+    }
+
+    /**
+     * The resource pack delivery of this lobby. A season change calls
+     * {@code applySeason} on it.
+     *
+     * @return the resource pack service
+     */
+    public ResourcePackService resourcePackService() {
+        return this.resourcePackService;
     }
 
     public static Titan instance() {

--- a/app/src/main/java/net/onelitefeather/titan/app/Titan.java
+++ b/app/src/main/java/net/onelitefeather/titan/app/Titan.java
@@ -37,6 +37,9 @@ import net.onelitefeather.titan.common.deliver.DeliverProvider;
 import net.onelitefeather.titan.common.event.EntityDismountEvent;
 import net.onelitefeather.titan.common.helper.BlockHandlerHelper;
 import net.onelitefeather.titan.common.map.MapProvider;
+import net.onelitefeather.titan.common.resourcepack.PackFailureNotice;
+import net.onelitefeather.titan.common.resourcepack.PackSlot;
+import net.onelitefeather.titan.common.resourcepack.ResourcePackSeasonWatcher;
 import net.onelitefeather.titan.common.resourcepack.ResourcePackService;
 import net.onelitefeather.titan.common.resourcepack.ResourcePackSettings;
 import net.onelitefeather.titan.common.resourcepack.ResourcePackSettingsProvider;
@@ -53,6 +56,7 @@ public final class Titan {
     private final AppConfigProvider appConfigProvider;
     private final NavigationHelper navigationHelper;
     private final ResourcePackService resourcePackService;
+    private final ResourcePackSeasonWatcher resourcePackSeasonWatcher;
 
     public Titan() {
         MinecraftServer.getConnectionManager().setPlayerProvider(TitanPlayer::new);
@@ -66,7 +70,8 @@ public final class Titan {
         // Without a resource-packs.json this stays disabled and no listener is registered
         // below, so a lobby without a pack server behaves exactly as it did before.
         ResourcePackSettings resourcePackSettings = ResourcePackSettingsProvider.load(this.path);
-        this.resourcePackService = ResourcePackService.create(resourcePackSettings);
+        this.resourcePackService = ResourcePackService.create(resourcePackSettings).withCondition(PackSlot.BASE, new PackFailureNotice(PackSlot.BASE)).withCondition(PackSlot.SEASON, new PackFailureNotice(PackSlot.SEASON));
+        this.resourcePackSeasonWatcher = ResourcePackSeasonWatcher.create(this.path, this.resourcePackService);
     }
 
     public void initialize() {
@@ -79,6 +84,7 @@ public final class Titan {
     }
 
     public void terminate() {
+        this.resourcePackSeasonWatcher.close();
         this.resourcePackService.close();
     }
 
@@ -123,8 +129,9 @@ public final class Titan {
     }
 
     /**
-     * Registers the resource pack listeners - but only when a pack is actually configured. An
-     * unconfigured lobby registers nothing at all and therefore cannot send a single pack packet.
+     * Registers the resource pack listeners and starts watching for season changes - but only
+     * when a pack is actually configured. An unconfigured lobby registers nothing at all and
+     * therefore cannot send a single pack packet.
      */
     private void initResourcePackListeners() {
         if (!this.resourcePackService.enabled()) {
@@ -133,16 +140,27 @@ public final class Titan {
         this.eventNode.addListener(AsyncPlayerConfigurationEvent.class, new ResourcePackConfigurationListener(this.resourcePackService));
         this.eventNode.addListener(PlayerResourcePackStatusEvent.class, new ResourcePackStatusListener(this.resourcePackService));
         this.eventNode.addListener(PlayerDisconnectEvent.class, new ResourcePackDisconnectListener(this.resourcePackService));
+        // Without this the season only ever changes on a restart: applySeason would have no
+        // caller and an edited resource-packs.json would reach nobody who is already online.
+        this.resourcePackSeasonWatcher.start();
     }
 
     /**
-     * The resource pack delivery of this lobby. A season change calls
-     * {@code applySeason} on it.
+     * The resource pack delivery of this lobby.
      *
      * @return the resource pack service
      */
     public ResourcePackService resourcePackService() {
         return this.resourcePackService;
+    }
+
+    /**
+     * The watcher that turns an edited {@code resource-packs.json} into a season change.
+     *
+     * @return the season watcher
+     */
+    public ResourcePackSeasonWatcher resourcePackSeasonWatcher() {
+        return this.resourcePackSeasonWatcher;
     }
 
     public static Titan instance() {

--- a/app/src/main/java/net/onelitefeather/titan/app/listener/ResourcePackConfigurationListener.java
+++ b/app/src/main/java/net/onelitefeather/titan/app/listener/ResourcePackConfigurationListener.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.app.listener;
+
+import net.minestom.server.event.player.AsyncPlayerConfigurationEvent;
+import net.onelitefeather.titan.common.resourcepack.ResourcePackService;
+
+import java.util.function.Consumer;
+
+/**
+ * Pushes the configured resource packs while the player is still in the configuration phase, so
+ * the client downloads them before it reaches the lobby.
+ *
+ * <p>This runs on the configuration thread that {@code ConnectionManager.doConfiguration()} will
+ * park on the pack future a moment later; the service arms its own timeout here so that thread
+ * cannot be parked forever.
+ *
+ * @author TheMeinerLP
+ * @version 1.0.0
+ * @since 1.15.0
+ */
+public final class ResourcePackConfigurationListener implements Consumer<AsyncPlayerConfigurationEvent> {
+
+    private final ResourcePackService resourcePackService;
+
+    /**
+     * Creates the listener.
+     *
+     * @param resourcePackService the service that decides what to deliver
+     */
+    public ResourcePackConfigurationListener(ResourcePackService resourcePackService) {
+        this.resourcePackService = resourcePackService;
+    }
+
+    @Override
+    public void accept(AsyncPlayerConfigurationEvent event) {
+        this.resourcePackService.onConfiguration(event.getPlayer());
+    }
+}

--- a/app/src/main/java/net/onelitefeather/titan/app/listener/ResourcePackDisconnectListener.java
+++ b/app/src/main/java/net/onelitefeather/titan/app/listener/ResourcePackDisconnectListener.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.app.listener;
+
+import net.minestom.server.event.player.PlayerDisconnectEvent;
+import net.onelitefeather.titan.common.resourcepack.ResourcePackService;
+
+import java.util.function.Consumer;
+
+/**
+ * Forgets which packs a player held once they leave, so the bookkeeping does not grow with every
+ * player the lobby has ever seen.
+ *
+ * @author TheMeinerLP
+ * @version 1.0.0
+ * @since 1.15.0
+ */
+public final class ResourcePackDisconnectListener implements Consumer<PlayerDisconnectEvent> {
+
+    private final ResourcePackService resourcePackService;
+
+    /**
+     * Creates the listener.
+     *
+     * @param resourcePackService the service keeping the book
+     */
+    public ResourcePackDisconnectListener(ResourcePackService resourcePackService) {
+        this.resourcePackService = resourcePackService;
+    }
+
+    @Override
+    public void accept(PlayerDisconnectEvent event) {
+        this.resourcePackService.onDisconnect(event.getPlayer().getUuid());
+    }
+}

--- a/app/src/main/java/net/onelitefeather/titan/app/listener/ResourcePackStatusListener.java
+++ b/app/src/main/java/net/onelitefeather/titan/app/listener/ResourcePackStatusListener.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.app.listener;
+
+import net.minestom.server.event.player.PlayerResourcePackStatusEvent;
+import net.onelitefeather.titan.common.resourcepack.ResourcePackService;
+
+import java.util.function.Consumer;
+
+/**
+ * Feeds a client's answer to a pushed pack back into the resource pack bookkeeping.
+ *
+ * @author TheMeinerLP
+ * @version 1.0.0
+ * @since 1.15.0
+ */
+public final class ResourcePackStatusListener implements Consumer<PlayerResourcePackStatusEvent> {
+
+    private final ResourcePackService resourcePackService;
+
+    /**
+     * Creates the listener.
+     *
+     * @param resourcePackService the service keeping the book
+     */
+    public ResourcePackStatusListener(ResourcePackService resourcePackService) {
+        this.resourcePackService = resourcePackService;
+    }
+
+    @Override
+    public void accept(PlayerResourcePackStatusEvent event) {
+        this.resourcePackService.onStatus(event.getPlayer(), event.getPackUuid(), event.getStatus());
+    }
+}

--- a/app/src/main/java/net/onelitefeather/titan/app/listener/package-info.java
+++ b/app/src/main/java/net/onelitefeather/titan/app/listener/package-info.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+/**
+ * Event listeners of the Titan lobby.
+ *
+ * @author TheMeinerLP
+ * @version 1.0.0
+ * @since 1.15.0
+ */
+@NotNullByDefault
+package net.onelitefeather.titan.app.listener;
+
+import org.jetbrains.annotations.NotNullByDefault;

--- a/app/src/test/java/net/onelitefeather/titan/app/listener/ResourcePackConfigurationListenerTest.java
+++ b/app/src/test/java/net/onelitefeather/titan/app/listener/ResourcePackConfigurationListenerTest.java
@@ -42,6 +42,8 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -49,7 +51,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ResourcePackConfigurationListenerTest {
 
     private static final String HASH = "4444444444444444444444444444444444444444";
+    private static final String OPTIONAL_HASH = "5555555555555555555555555555555555555555";
     private static final ResourcePackDefinition REQUIRED_PACK = new ResourcePackDefinition(UUID.fromString("00000000-0000-4000-8000-0000000000aa"), "https://packs.invalid/pack-" + HASH + ".zip", HASH, true, null);
+    private static final ResourcePackDefinition OPTIONAL_PACK = new ResourcePackDefinition(UUID.fromString("00000000-0000-4000-8000-0000000000bb"), "https://packs.invalid/pack-" + OPTIONAL_HASH + ".zip", OPTIONAL_HASH, false, null);
 
     @Test
     @DisplayName("A client that never answers does not park the configuration thread forever")
@@ -71,7 +75,31 @@ class ResourcePackConfigurationListenerTest {
             List<ResourcePackPushPacket> pushed = pushes.collect();
             assertEquals(1, pushed.size());
             assertTrue(pushed.getFirst().forced());
-            assertTrue(service.registry().holds(player.getUuid(), PackSlot.BASE, REQUIRED_PACK.id()));
+            // The guard answers on the silent client's behalf, so Minestom clears its own
+            // bookkeeping instead of being left with a pack that is pending forever. For this
+            // pack that answer also means a kick, because the configuration marks it required.
+            assertNull(player.getResourcePackFuture(), "The expired request must not stay in the player's future field");
+            assertFalse(service.registry().holds(player.getUuid(), PackSlot.BASE, REQUIRED_PACK.id()), "A pack that timed out is not held");
+        }
+    }
+
+    @Test
+    @DisplayName("An optional pack that times out lets the player in without it")
+    void testSilentClientKeepsAnOptionalPack(Env env) {
+        ResourcePackSettings settings = new ResourcePackSettings(OPTIONAL_PACK, null, 250L, false, ".");
+        try (DaemonPackTimeoutScheduler scheduler = new DaemonPackTimeoutScheduler()) {
+            ResourcePackService service = new ResourcePackService(settings, new HeldPackRegistry(), BedrockDetector.never(), scheduler);
+            MinecraftServer.getGlobalEventHandler().addListener(AsyncPlayerConfigurationEvent.class, new ResourcePackConfigurationListener(service));
+
+            Instance instance = env.createFlatInstance();
+            TestConnection connection = env.createConnection();
+            Collector<ResourcePackPushPacket> pushes = connection.trackIncoming(ResourcePackPushPacket.class);
+
+            Player player = assertTimeoutPreemptively(Duration.ofSeconds(15), () -> connection.connect(instance));
+
+            pushes.assertSingle(packet -> assertFalse(packet.forced()));
+            assertTrue(player.isOnline(), "An optional pack that timed out must not cost the player their session");
+            assertNull(player.getResourcePackFuture(), "The expired request must not stay in the player's future field");
         }
     }
 

--- a/app/src/test/java/net/onelitefeather/titan/app/listener/ResourcePackConfigurationListenerTest.java
+++ b/app/src/test/java/net/onelitefeather/titan/app/listener/ResourcePackConfigurationListenerTest.java
@@ -104,6 +104,53 @@ class ResourcePackConfigurationListenerTest {
     }
 
     @Test
+    @DisplayName("With the kick flag active a required pack that times out costs the session")
+    void testRequiredPackKickFlagActiveDisconnectsTheSilentClient(Env env) {
+        ResourcePackSettings settings = new ResourcePackSettings(REQUIRED_PACK, null, 250L, false, ".");
+        try (DaemonPackTimeoutScheduler scheduler = new DaemonPackTimeoutScheduler()) {
+            ResourcePackService service = new ResourcePackService(settings, new HeldPackRegistry(), BedrockDetector.never(), scheduler, () -> true);
+            MinecraftServer.getGlobalEventHandler().addListener(AsyncPlayerConfigurationEvent.class, new ResourcePackConfigurationListener(service));
+
+            Instance instance = env.createFlatInstance();
+            TestConnection connection = env.createConnection();
+            Collector<ResourcePackPushPacket> pushes = connection.trackIncoming(ResourcePackPushPacket.class);
+
+            Player player = assertTimeoutPreemptively(Duration.ofSeconds(15), () -> connection.connect(instance));
+
+            pushes.assertSingle(packet -> assertTrue(packet.forced(), "An enforced pack is pushed with the forced bit set"));
+            assertFalse(player.isOnline(), "A silent client must lose its session while the kick flag is active");
+        }
+    }
+
+    @Test
+    @DisplayName("With the kick flag inactive the same pack lets the silent client in, and still leaves no stale state")
+    void testRequiredPackKickFlagInactiveAdmitsTheSilentClient(Env env) {
+        // The very same REQUIRED_PACK as the test above - only the flag differs.
+        ResourcePackSettings settings = new ResourcePackSettings(REQUIRED_PACK, null, 250L, false, ".");
+        try (DaemonPackTimeoutScheduler scheduler = new DaemonPackTimeoutScheduler()) {
+            ResourcePackService service = new ResourcePackService(settings, new HeldPackRegistry(), BedrockDetector.never(), scheduler, () -> false);
+            MinecraftServer.getGlobalEventHandler().addListener(AsyncPlayerConfigurationEvent.class, new ResourcePackConfigurationListener(service));
+
+            Instance instance = env.createFlatInstance();
+            TestConnection connection = env.createConnection();
+            Collector<ResourcePackPushPacket> pushes = connection.trackIncoming(ResourcePackPushPacket.class);
+
+            Player player = assertTimeoutPreemptively(Duration.ofSeconds(15), () -> connection.connect(instance));
+
+            // A pack the lobby will not enforce is not advertised as forced either, so the
+            // client's accept dialog does not promise something the server does not do.
+            pushes.assertSingle(packet -> assertFalse(packet.forced(), "An unenforced pack must not be pushed as forced"));
+            assertTrue(player.isOnline(), "With the kick flag inactive a silent client keeps its session");
+            // The reason the guard exists in the first place has to survive the flag being off.
+            // Minestom nulls the future field only after emptying its own pending map, so a null
+            // future here is proof that the pack is gone from that map as well - and that a later
+            // configuration pass gets a fresh future instead of an already-completed one.
+            assertNull(player.getResourcePackFuture(), "The expired request must not stay in the player's future field");
+            assertFalse(service.registry().holds(player.getUuid(), PackSlot.BASE, REQUIRED_PACK.id()), "A pack that timed out is not held");
+        }
+    }
+
+    @Test
     @DisplayName("A disconnect makes the lobby forget which packs the player held")
     void testDisconnectListenerClearsTheBook(Env env) {
         ResourcePackSettings settings = new ResourcePackSettings(REQUIRED_PACK, null, -1L, false, ".");

--- a/app/src/test/java/net/onelitefeather/titan/app/listener/ResourcePackConfigurationListenerTest.java
+++ b/app/src/test/java/net/onelitefeather/titan/app/listener/ResourcePackConfigurationListenerTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.app.listener;
+
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.entity.Player;
+import net.minestom.server.event.player.AsyncPlayerConfigurationEvent;
+import net.minestom.server.event.player.PlayerDisconnectEvent;
+import net.minestom.server.instance.Instance;
+import net.minestom.server.network.packet.server.common.ResourcePackPushPacket;
+import net.minestom.testing.Collector;
+import net.minestom.testing.Env;
+import net.minestom.testing.TestConnection;
+import net.minestom.testing.extension.MicrotusExtension;
+import net.onelitefeather.titan.common.resourcepack.BedrockDetector;
+import net.onelitefeather.titan.common.resourcepack.DaemonPackTimeoutScheduler;
+import net.onelitefeather.titan.common.resourcepack.HeldPackRegistry;
+import net.onelitefeather.titan.common.resourcepack.PackSlot;
+import net.onelitefeather.titan.common.resourcepack.ResourcePackDefinition;
+import net.onelitefeather.titan.common.resourcepack.ResourcePackService;
+import net.onelitefeather.titan.common.resourcepack.ResourcePackSettings;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MicrotusExtension.class)
+class ResourcePackConfigurationListenerTest {
+
+    private static final String HASH = "4444444444444444444444444444444444444444";
+    private static final ResourcePackDefinition REQUIRED_PACK = new ResourcePackDefinition(UUID.fromString("00000000-0000-4000-8000-0000000000aa"), "https://packs.invalid/pack-" + HASH + ".zip", HASH, true, null);
+
+    @Test
+    @DisplayName("A client that never answers does not park the configuration thread forever")
+    void testSilentClientDoesNotBlockConfiguration(Env env) {
+        // The test connection never answers a pack push, and
+        // ConnectionManager.doConfiguration() joins the pack future without a timeout - so
+        // without the service's own guard this connect() would never return.
+        ResourcePackSettings settings = new ResourcePackSettings(REQUIRED_PACK, null, 250L, false, ".");
+        try (DaemonPackTimeoutScheduler scheduler = new DaemonPackTimeoutScheduler()) {
+            ResourcePackService service = new ResourcePackService(settings, new HeldPackRegistry(), BedrockDetector.never(), scheduler);
+            MinecraftServer.getGlobalEventHandler().addListener(AsyncPlayerConfigurationEvent.class, new ResourcePackConfigurationListener(service));
+
+            Instance instance = env.createFlatInstance();
+            TestConnection connection = env.createConnection();
+            Collector<ResourcePackPushPacket> pushes = connection.trackIncoming(ResourcePackPushPacket.class);
+
+            Player player = assertTimeoutPreemptively(Duration.ofSeconds(15), () -> connection.connect(instance));
+
+            List<ResourcePackPushPacket> pushed = pushes.collect();
+            assertEquals(1, pushed.size());
+            assertTrue(pushed.getFirst().forced());
+            assertTrue(service.registry().holds(player.getUuid(), PackSlot.BASE, REQUIRED_PACK.id()));
+        }
+    }
+
+    @Test
+    @DisplayName("A disconnect makes the lobby forget which packs the player held")
+    void testDisconnectListenerClearsTheBook(Env env) {
+        ResourcePackSettings settings = new ResourcePackSettings(REQUIRED_PACK, null, -1L, false, ".");
+        ResourcePackService service = new ResourcePackService(settings, new HeldPackRegistry(), BedrockDetector.never(), (task, delay) -> {
+        });
+
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+        service.onConfiguration(player);
+        assertEquals(1, service.registry().trackedPlayers());
+
+        new ResourcePackDisconnectListener(service).accept(new PlayerDisconnectEvent(player));
+
+        assertEquals(0, service.registry().trackedPlayers());
+    }
+}

--- a/common/src/main/java/net/onelitefeather/titan/common/resourcepack/BedrockDetector.java
+++ b/common/src/main/java/net/onelitefeather/titan/common/resourcepack/BedrockDetector.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.common.resourcepack;
+
+import net.minestom.server.entity.Player;
+
+import java.util.UUID;
+
+/**
+ * Recognises players who reach the lobby through Geyser.
+ *
+ * <p>This exists because the reported pack status cannot be trusted for them: for a required
+ * pack Geyser answers {@code ACCEPTED}, {@code DOWNLOADED} and {@code SUCCESSFULLY_LOADED} on
+ * the player's behalf, even though nothing was ever delivered to the Bedrock client. Since the
+ * lie is indistinguishable from a real success, the platform has to be recognised up front
+ * instead of inferred from the answer.
+ *
+ * @author TheMeinerLP
+ * @version 1.0.0
+ * @since 1.15.0
+ */
+@FunctionalInterface
+public interface BedrockDetector {
+
+    /**
+     * Whether a player is connected through Geyser.
+     *
+     * @param playerId the player's unique id
+     * @param username the player's name
+     * @return {@code true} when the player is a Bedrock player
+     */
+    boolean isBedrock(UUID playerId, String username);
+
+    /**
+     * Whether a player is connected through Geyser.
+     *
+     * @param player the player to inspect
+     * @return {@code true} when the player is a Bedrock player
+     */
+    default boolean isBedrock(Player player) {
+        return this.isBedrock(player.getUuid(), player.getUsername());
+    }
+
+    /**
+     * A detector that treats every player as a Java player. Useful for tests and for lobbies
+     * that are not reachable from Bedrock at all.
+     *
+     * @return a detector that never reports Bedrock
+     */
+    static BedrockDetector never() {
+        return (playerId, username) -> false;
+    }
+
+    /**
+     * The detector Titan uses in production.
+     *
+     * @param namePrefix the Floodgate name prefix, empty to match on the id alone
+     * @return a detector recognising Floodgate ids and name prefixes
+     */
+    static BedrockDetector floodgate(String namePrefix) {
+        return new FloodgateBedrockDetector(namePrefix);
+    }
+}

--- a/common/src/main/java/net/onelitefeather/titan/common/resourcepack/DaemonPackTimeoutScheduler.java
+++ b/common/src/main/java/net/onelitefeather/titan/common/resourcepack/DaemonPackTimeoutScheduler.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.common.resourcepack;
+
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The production {@link PackTimeoutScheduler}: a single daemon thread that fires the pending
+ * timeout guards.
+ *
+ * <p>One thread is enough because a guard only reads a future and completes it. The thread is a
+ * daemon so a lingering timeout can never keep the JVM alive after shutdown.
+ *
+ * @author TheMeinerLP
+ * @version 1.0.0
+ * @since 1.15.0
+ */
+public final class DaemonPackTimeoutScheduler implements PackTimeoutScheduler, AutoCloseable {
+
+    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(runnable -> Thread.ofPlatform().name("titan-resourcepack-timeout").daemon(true).unstarted(runnable));
+
+    @Override
+    public void schedule(Runnable task, Duration delay) {
+        this.executor.schedule(task, Math.max(0L, delay.toMillis()), TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Stops the scheduler. Pending guards are dropped; the configuration threads they would have
+     * released are gone by then anyway.
+     */
+    @Override
+    public void close() {
+        this.executor.shutdownNow();
+    }
+}

--- a/common/src/main/java/net/onelitefeather/titan/common/resourcepack/FloodgateBedrockDetector.java
+++ b/common/src/main/java/net/onelitefeather/titan/common/resourcepack/FloodgateBedrockDetector.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.common.resourcepack;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Recognises Bedrock players the way Floodgate marks them, without depending on the Floodgate
+ * API.
+ *
+ * <p>Two independent signals, either of which is enough:
+ * <ul>
+ * <li>Floodgate builds a player's unique id as {@code new UUID(0L, xuid)}, so the whole upper
+ * half is zero. A Java id never looks like that: both the online-mode ids from Mojang and the
+ * offline-mode ids Minestom derives are version-3 or version-4 UUIDs and carry their version
+ * nibble in the upper half.</li>
+ * <li>Floodgate prepends a configurable prefix - {@code .} by default - to the Bedrock
+ * gamertag. This catches setups where the proxy resolves the linked Java account and the id no
+ * longer shows the Floodgate shape.</li>
+ * </ul>
+ *
+ * @author TheMeinerLP
+ * @version 1.0.0
+ * @since 1.15.0
+ */
+public final class FloodgateBedrockDetector implements BedrockDetector {
+
+    private final String namePrefix;
+
+    /**
+     * Creates a detector for a Floodgate setup.
+     *
+     * @param namePrefix the configured Floodgate name prefix; an empty string disables the name
+     *                   check and leaves only the id check
+     */
+    public FloodgateBedrockDetector(String namePrefix) {
+        this.namePrefix = Objects.requireNonNull(namePrefix, "The bedrock name prefix must not be null");
+    }
+
+    @Override
+    public boolean isBedrock(UUID playerId, String username) {
+        if (playerId.getMostSignificantBits() == 0L) {
+            return true;
+        }
+        return !this.namePrefix.isEmpty() && username.startsWith(this.namePrefix);
+    }
+}

--- a/common/src/main/java/net/onelitefeather/titan/common/resourcepack/HeldPackRegistry.java
+++ b/common/src/main/java/net/onelitefeather/titan/common/resourcepack/HeldPackRegistry.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.common.resourcepack;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Remembers which pack sits in which slot for every player.
+ *
+ * <p>Minestom tracks only the packs whose answer is still outstanding
+ * ({@code Player#pendingResourcePacks}) and forgets a pack the moment the client reports a
+ * terminal status. Nothing in the server knows afterwards what a player actually holds - but
+ * that is exactly what a season change needs, because it must pop the identifier the player was
+ * given, which may be an older season than the one currently configured. So the lobby keeps this
+ * book itself.
+ *
+ * <p>An entry is created when a pack is pushed ({@link #markSent}) and promoted when the client
+ * confirms it ({@link #confirm}). Both states count as held: a pack that was pushed but never
+ * answered may still be sitting in the client, and popping an identifier the client does not
+ * have is harmless, while failing to pop one it does have is not.
+ *
+ * <p>All methods are safe to call from several threads - pushes happen on configuration threads,
+ * a season change on whichever thread triggers it.
+ *
+ * @author TheMeinerLP
+ * @version 1.0.0
+ * @since 1.15.0
+ */
+public final class HeldPackRegistry {
+
+    private final Map<UUID, Map<PackSlot, Entry>> byPlayer = new ConcurrentHashMap<>();
+
+    /**
+     * One pack a player was given.
+     *
+     * @param packId    the pack identifier that was pushed
+     * @param confirmed whether the client reported it as successfully loaded
+     * @author TheMeinerLP
+     * @version 1.0.0
+     * @since 1.15.0
+     */
+    public record Entry(UUID packId, boolean confirmed) {
+    }
+
+    /**
+     * Records that a pack was pushed to a player, replacing whatever that slot held before.
+     *
+     * @param playerId the player the pack was pushed to
+     * @param slot     the slot the pack fills
+     * @param packId   the pushed pack identifier
+     */
+    public void markSent(UUID playerId, PackSlot slot, UUID packId) {
+        this.byPlayer.computeIfAbsent(playerId, key -> new ConcurrentHashMap<>()).put(slot, new Entry(packId, false));
+    }
+
+    /**
+     * Marks the pack in a slot as confirmed by the client. Does nothing when the slot is empty.
+     *
+     * @param playerId the player who answered
+     * @param slot     the slot that was confirmed
+     */
+    public void confirm(UUID playerId, PackSlot slot) {
+        this.byPlayer.computeIfPresent(playerId, (key, slots) -> {
+            Entry entry = slots.get(slot);
+            if (entry != null) {
+                slots.put(slot, new Entry(entry.packId(), true));
+            }
+            return slots;
+        });
+    }
+
+    /**
+     * Forgets the pack in a slot, because the client declined it, failed to load it or had it
+     * removed.
+     *
+     * @param playerId the player to update
+     * @param slot     the slot to clear
+     */
+    public void forget(UUID playerId, PackSlot slot) {
+        this.byPlayer.computeIfPresent(playerId, (key, slots) -> {
+            slots.remove(slot);
+            return slots.isEmpty() ? null : slots;
+        });
+    }
+
+    /**
+     * Forgets everything about a player, for instance when they disconnect.
+     *
+     * @param playerId the player to drop
+     */
+    public void forget(UUID playerId) {
+        this.byPlayer.remove(playerId);
+    }
+
+    /**
+     * The pack a player holds in a slot, whether or not the client confirmed it.
+     *
+     * @param playerId the player to look up
+     * @param slot     the slot to look up
+     * @return the entry, or empty when the player holds nothing in that slot
+     */
+    public Optional<Entry> entry(UUID playerId, PackSlot slot) {
+        Map<PackSlot, Entry> slots = this.byPlayer.get(playerId);
+        return slots == null ? Optional.empty() : Optional.ofNullable(slots.get(slot));
+    }
+
+    /**
+     * Whether a player already holds a specific pack, so it does not need to be pushed again.
+     *
+     * @param playerId the player to look up
+     * @param slot     the slot to look up
+     * @param packId   the pack identifier to compare against
+     * @return {@code true} when that exact pack sits in that slot
+     */
+    public boolean holds(UUID playerId, PackSlot slot, UUID packId) {
+        return this.entry(playerId, slot).filter(entry -> entry.packId().equals(packId)).isPresent();
+    }
+
+    /**
+     * Resolves which slot a pack identifier belongs to for a player. Needed to route a status
+     * report, which carries only the pack identifier, to the right slot.
+     *
+     * @param playerId the player who reported
+     * @param packId   the reported pack identifier
+     * @return the slot, or {@code null} when the player was never given that pack
+     */
+    public @Nullable PackSlot slotOf(UUID playerId, UUID packId) {
+        Map<PackSlot, Entry> slots = this.byPlayer.get(playerId);
+        if (slots == null) {
+            return null;
+        }
+        for (Map.Entry<PackSlot, Entry> candidate : slots.entrySet()) {
+            if (candidate.getValue().packId().equals(packId)) {
+                return candidate.getKey();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * The number of players the registry currently knows about. Intended for tests and
+     * diagnostics.
+     *
+     * @return the number of tracked players
+     */
+    public int trackedPlayers() {
+        return this.byPlayer.size();
+    }
+}

--- a/common/src/main/java/net/onelitefeather/titan/common/resourcepack/PackFailureNotice.java
+++ b/common/src/main/java/net/onelitefeather/titan/common/resourcepack/PackFailureNotice.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.common.resourcepack;
+
+import net.kyori.adventure.resource.ResourcePackStatus;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.minestom.server.entity.Player;
+import net.theevilreaper.aves.resourcepack.ResourcePackCondition;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Locale;
+
+/**
+ * Tells a player that a resource pack did not make it, instead of leaving them to wonder why the
+ * lobby looks wrong.
+ *
+ * <p>This is the condition {@link ResourcePackService#withCondition} exists for. Only the three
+ * statuses that mean "the pack is broken or unreachable" produce a message:
+ * {@link ResourcePackStatus#FAILED_DOWNLOAD}, {@link ResourcePackStatus#INVALID_URL} and
+ * {@link ResourcePackStatus#FAILED_RELOAD}. They are also logged, because all three point at the
+ * pack server rather than at the player.
+ *
+ * <p>{@link ResourcePackStatus#DECLINED} is deliberately silent: the player chose it, and for a
+ * required pack Minestom has already kicked them by the time this runs. Nagging someone about a
+ * choice they just made is not a notice, it is noise.
+ *
+ * @author TheMeinerLP
+ * @version 1.0.0
+ * @since 1.15.0
+ */
+public final class PackFailureNotice implements ResourcePackCondition {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PackFailureNotice.class);
+
+    private static final String DEFAULT_MESSAGE = "<gray>The <yellow><slot></yellow> resource pack could not be loaded. The lobby works without it, but you will not see its textures.";
+
+    private final PackSlot slot;
+    private final Component message;
+
+    /**
+     * Creates the notice for one slot.
+     *
+     * @param slot the slot this notice reports on
+     */
+    public PackFailureNotice(PackSlot slot) {
+        this(slot, MiniMessage.miniMessage().deserialize(DEFAULT_MESSAGE.replace("<slot>", slot.name().toLowerCase(Locale.ROOT))));
+    }
+
+    /**
+     * Creates the notice with a message of its own.
+     *
+     * @param slot    the slot this notice reports on
+     * @param message the message sent to the player
+     */
+    public PackFailureNotice(PackSlot slot, Component message) {
+        this.slot = slot;
+        this.message = message;
+    }
+
+    @Override
+    public void handleStatus(@NotNull Player player, @NotNull ResourcePackStatus resourcePackStatus) {
+        switch (resourcePackStatus) {
+            case FAILED_DOWNLOAD, INVALID_URL, FAILED_RELOAD -> {
+                LOGGER.warn("The {} resource pack failed for {} with {} - check that the configured url is reachable and serves the configured hash", this.slot, player.getUsername(), resourcePackStatus);
+                player.sendMessage(this.message);
+            }
+            default -> {
+                // Nothing to report: the pack loaded, or the player declined it on purpose.
+            }
+        }
+    }
+}

--- a/common/src/main/java/net/onelitefeather/titan/common/resourcepack/PackSlot.java
+++ b/common/src/main/java/net/onelitefeather/titan/common/resourcepack/PackSlot.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.common.resourcepack;
+
+/**
+ * The role a resource pack plays in the stack the lobby delivers.
+ *
+ * <p>Since 1.20.3 a client can hold several packs at once, each addressed by its own
+ * identifier. Titan uses exactly two roles: a large {@link #BASE} pack that stays in the
+ * client cache across season changes, and a small {@link #SEASON} delta that is popped and
+ * pushed on its own when the season turns.
+ *
+ * @author TheMeinerLP
+ * @version 1.0.0
+ * @since 1.15.0
+ */
+public enum PackSlot {
+
+    /**
+     * The long-lived pack. Its identifier never changes, so the client keeps it cached
+     * across season changes and server switches.
+     */
+    BASE,
+
+    /**
+     * The seasonal delta pack. It carries its own identifier and is the only pack removed
+     * and replaced when the season changes.
+     */
+    SEASON
+}

--- a/common/src/main/java/net/onelitefeather/titan/common/resourcepack/PackTimeoutScheduler.java
+++ b/common/src/main/java/net/onelitefeather/titan/common/resourcepack/PackTimeoutScheduler.java
@@ -41,12 +41,23 @@ public interface PackTimeoutScheduler {
     void schedule(Runnable task, Duration delay);
 
     /**
-     * A scheduler that runs the task immediately on the calling thread. Only meaningful in
-     * tests, where it turns the timeout into a synchronous call.
+     * A scheduler that runs the task immediately on the calling thread, as though the client had
+     * already fallen silent. Only meaningful in tests.
      *
      * @return an immediate scheduler
      */
     static PackTimeoutScheduler immediate() {
         return (task, delay) -> task.run();
+    }
+
+    /**
+     * A scheduler that never runs the task, as though every client answered in time. Useful in
+     * tests that are about delivery rather than about the guard.
+     *
+     * @return a scheduler that drops every guard
+     */
+    static PackTimeoutScheduler never() {
+        return (task, delay) -> {
+        };
     }
 }

--- a/common/src/main/java/net/onelitefeather/titan/common/resourcepack/PackTimeoutScheduler.java
+++ b/common/src/main/java/net/onelitefeather/titan/common/resourcepack/PackTimeoutScheduler.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.common.resourcepack;
+
+import java.time.Duration;
+
+/**
+ * Runs the resource pack timeout guard after a delay.
+ *
+ * <p>Deliberately not Minestom's scheduler: the guard has to fire while a configuration thread
+ * is parked inside {@code ConnectionManager.doConfiguration()}, and it must be replaceable in
+ * tests so the timeout path can be exercised without waiting for real time to pass.
+ *
+ * @author TheMeinerLP
+ * @version 1.0.0
+ * @since 1.15.0
+ */
+@FunctionalInterface
+public interface PackTimeoutScheduler {
+
+    /**
+     * Runs a task once, after the given delay.
+     *
+     * @param task  the guard to run
+     * @param delay how long to wait before running it
+     */
+    void schedule(Runnable task, Duration delay);
+
+    /**
+     * A scheduler that runs the task immediately on the calling thread. Only meaningful in
+     * tests, where it turns the timeout into a synchronous call.
+     *
+     * @return an immediate scheduler
+     */
+    static PackTimeoutScheduler immediate() {
+        return (task, delay) -> task.run();
+    }
+}

--- a/common/src/main/java/net/onelitefeather/titan/common/resourcepack/ResourcePackDefinition.java
+++ b/common/src/main/java/net/onelitefeather/titan/common/resourcepack/ResourcePackDefinition.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.common.resourcepack;
+
+import net.kyori.adventure.resource.ResourcePackInfo;
+import net.kyori.adventure.resource.ResourcePackRequest;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.jetbrains.annotations.Nullable;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+/**
+ * One resource pack as it is configured: a stable identifier, the URL it is served from and
+ * the SHA-1 of the archive behind that URL.
+ *
+ * <p>The identifier is what {@code resource_pack_pop} addresses, so it has to stay stable for
+ * the base pack and has to differ per season for the season pack. The hash is mandatory: the
+ * vanilla client caches downloaded packs <em>by URL, not by hash</em>, so a changed pack served
+ * from an unchanged URL is never re-downloaded. Serve every pack under a content-addressed name
+ * ({@code pack-<sha1>.zip}) and the cache problem disappears - {@link #contentAddressed()}
+ * reports whether a configured URL follows that rule.
+ *
+ * @param id       the pack identifier sent to the client and used by {@code resource_pack_pop}
+ * @param url      the URL the client downloads the archive from
+ * @param hash     the SHA-1 of the archive, 40 hexadecimal characters
+ * @param required whether the client must load the pack to stay connected
+ * @param prompt   an optional MiniMessage prompt shown in the client's accept dialog
+ * @author TheMeinerLP
+ * @version 1.0.0
+ * @since 1.15.0
+ */
+public record ResourcePackDefinition(UUID id, String url, String hash, boolean required,
+                                     @Nullable String prompt) {
+
+    private static final Pattern SHA1 = Pattern.compile("[0-9a-f]{40}");
+
+    /**
+     * Validates and normalises the configured values.
+     *
+     * @throws NullPointerException     if the identifier, URL or hash is missing
+     * @throws IllegalArgumentException if the URL is not a valid URI or the hash is not a SHA-1
+     */
+    public ResourcePackDefinition {
+        Objects.requireNonNull(id, "A resource pack needs an id");
+        Objects.requireNonNull(url, "A resource pack needs an url");
+        Objects.requireNonNull(hash, "A resource pack needs a sha1 hash");
+        if (url.isBlank()) {
+            throw new IllegalArgumentException("The resource pack url must not be blank");
+        }
+        try {
+            new URI(url);
+        } catch (URISyntaxException exception) {
+            throw new IllegalArgumentException("The resource pack url is not a valid uri: " + url, exception);
+        }
+        hash = hash.trim().toLowerCase(Locale.ROOT);
+        if (!SHA1.matcher(hash).matches()) {
+            throw new IllegalArgumentException("The resource pack hash must be a 40 character sha1, got: " + hash);
+        }
+    }
+
+    /**
+     * The URL as a {@link URI}.
+     *
+     * @return the download location of the pack
+     */
+    public URI uri() {
+        return URI.create(this.url);
+    }
+
+    /**
+     * Whether the download URL carries the hash, so that a changed pack is served under a
+     * changed URL. Only a content-addressed URL survives the client's URL-keyed cache.
+     *
+     * @return {@code true} if the URL contains the configured hash
+     */
+    public boolean contentAddressed() {
+        return this.url.toLowerCase(Locale.ROOT).contains(this.hash);
+    }
+
+    /**
+     * The Adventure description of this pack.
+     *
+     * @return the pack info carrying id, uri and hash
+     */
+    public ResourcePackInfo toPackInfo() {
+        return ResourcePackInfo.resourcePackInfo(this.id, this.uri(), this.hash);
+    }
+
+    /**
+     * Builds the push request for this single pack.
+     *
+     * <p>The request never sets {@code replace}: Minestom implements that flag as
+     * pop-all-then-push, which makes the client drop and reload every pack it holds. Packs are
+     * always added one at a time and removed by identifier.
+     *
+     * @param required whether the client must load the pack; overrides {@link #required()} so a
+     *                 caller can soften the requirement per player
+     * @return the request to hand to {@code Player#sendResourcePacks}
+     */
+    public ResourcePackRequest toRequest(boolean required) {
+        ResourcePackRequest.Builder builder = ResourcePackRequest.resourcePackRequest().packs(this.toPackInfo()).replace(false).required(required);
+        Component promptComponent = this.promptComponent();
+        if (promptComponent != null) {
+            builder.prompt(promptComponent);
+        }
+        return builder.build();
+    }
+
+    /**
+     * The deserialised prompt shown in the client's accept dialog.
+     *
+     * @return the prompt, or {@code null} when none is configured
+     */
+    public @Nullable Component promptComponent() {
+        if (this.prompt == null || this.prompt.isBlank()) {
+            return null;
+        }
+        return MiniMessage.miniMessage().deserialize(this.prompt);
+    }
+}

--- a/common/src/main/java/net/onelitefeather/titan/common/resourcepack/ResourcePackSeasonWatcher.java
+++ b/common/src/main/java/net/onelitefeather/titan/common/resourcepack/ResourcePackSeasonWatcher.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.common.resourcepack;
+
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.entity.Player;
+import net.minestom.server.timer.Scheduler;
+import net.minestom.server.timer.Task;
+import net.minestom.server.timer.TaskSchedule;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Makes a season change take effect on a running lobby.
+ *
+ * <p>Without this nothing ever calls {@link ResourcePackService#applySeason}: an operator swaps
+ * the Halloween entry in {@code resource-packs.json} for Winter and the players who are online
+ * keep Halloween until the process is restarted. US-6.02 asks for the opposite - the season pack
+ * is replaced when the season turns, not when the lobby next boots.
+ *
+ * <p>The trigger is the configuration file itself, re-read on a fixed interval. That is
+ * deliberate:
+ * <ul>
+ * <li>The file is already the control surface. An operator changes a season by editing it, and
+ * a deployment or a cron job can do the same at midnight without a console, a permission or a
+ * network call.</li>
+ * <li>It is how this project already treats file-based configuration. Togglz'
+ * {@code FileBasedStateRepository} - the state repository behind the lobby's feature flags -
+ * polls its file at 1000&nbsp;ms for exactly this reason.</li>
+ * <li>It needs no new command, no new permission and no coordination with a proxy, so nothing
+ * has to be reachable for a season to turn.</li>
+ * </ul>
+ *
+ * <p>Only the season slot is watched. A changed base pack, timeout or Bedrock setting is
+ * ignored, because swapping the large base pack under a lobby full of players is a restart-level
+ * decision, not something a file poll should do by itself.
+ *
+ * <p>The poll runs on Minestom's scheduler, which means it runs on the server tick thread. That
+ * matters: {@code Player#sendResourcePacks} writes into the same unsynchronised map that the
+ * packet handler reads, and the packet handler runs on the tick thread too.
+ *
+ * @author TheMeinerLP
+ * @version 1.0.0
+ * @since 1.15.0
+ */
+public final class ResourcePackSeasonWatcher implements AutoCloseable {
+
+    /** How often the configuration file is re-read when no interval is given. */
+    public static final Duration DEFAULT_INTERVAL = Duration.ofSeconds(5);
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResourcePackSeasonWatcher.class);
+
+    private final Path directory;
+    private final ResourcePackService service;
+    private final Supplier<Collection<Player>> onlinePlayers;
+    private final Duration interval;
+    private final Scheduler scheduler;
+    private volatile @Nullable Task task;
+
+    /**
+     * Creates a watcher with explicit collaborators. Tests use this to point the watcher at a
+     * temporary directory and to shorten the interval.
+     *
+     * @param directory     the directory holding {@code resource-packs.json}
+     * @param service       the service whose season is swapped
+     * @param onlinePlayers the players a swap has to reach
+     * @param interval      how often the file is re-read
+     * @param scheduler     the scheduler the poll runs on
+     */
+    public ResourcePackSeasonWatcher(Path directory, ResourcePackService service, Supplier<Collection<Player>> onlinePlayers, Duration interval, Scheduler scheduler) {
+        this.directory = Objects.requireNonNull(directory, "The configuration directory must not be null");
+        this.service = Objects.requireNonNull(service, "The resource pack service must not be null");
+        this.onlinePlayers = Objects.requireNonNull(onlinePlayers, "The player supplier must not be null");
+        this.interval = Objects.requireNonNull(interval, "The poll interval must not be null");
+        this.scheduler = Objects.requireNonNull(scheduler, "The scheduler must not be null");
+        if (interval.isZero() || interval.isNegative()) {
+            throw new IllegalArgumentException("The poll interval must be positive, got: " + interval);
+        }
+    }
+
+    /**
+     * Creates the watcher Titan runs with: the server's own scheduler, the server's online
+     * players and {@link #DEFAULT_INTERVAL}.
+     *
+     * @param directory the directory the server runs in
+     * @param service   the service whose season is swapped
+     * @return the watcher
+     */
+    public static ResourcePackSeasonWatcher create(Path directory, ResourcePackService service) {
+        return new ResourcePackSeasonWatcher(directory, service, () -> MinecraftServer.getConnectionManager().getOnlinePlayers(), DEFAULT_INTERVAL, MinecraftServer.getSchedulerManager());
+    }
+
+    /**
+     * Starts polling. Calling this twice has no effect beyond the first call.
+     */
+    public void start() {
+        if (this.task != null) {
+            return;
+        }
+        TaskSchedule schedule = TaskSchedule.duration(this.interval);
+        this.task = this.scheduler.scheduleTask(this::poll, schedule, schedule);
+        LOGGER.info("Watching {} for season changes every {}", this.directory.resolve(ResourcePackSettingsProvider.FILE_NAME), this.interval);
+    }
+
+    /**
+     * Re-reads the configuration once and swaps the season pack when it changed.
+     *
+     * <p>Public so a test can drive one poll without waiting for the timer, and so an operator
+     * command could later force one.
+     *
+     * @return {@code true} when a season change was applied
+     */
+    public boolean poll() {
+        Optional<ResourcePackSettings> loaded = ResourcePackSettingsProvider.reload(this.directory);
+        if (loaded.isEmpty()) {
+            return false;
+        }
+        ResourcePackDefinition configured = loaded.get().season();
+        ResourcePackDefinition current = this.service.settings().season();
+        if (Objects.equals(configured, current)) {
+            return false;
+        }
+        Collection<Player> players = this.onlinePlayers.get();
+        LOGGER.info("The season pack changed from {} to {} - swapping it for {} online player(s)", identify(current), identify(configured), players.size());
+        this.service.applySeason(configured, players);
+        return true;
+    }
+
+    /**
+     * Stops polling.
+     */
+    @Override
+    public void close() {
+        Task running = this.task;
+        this.task = null;
+        if (running != null) {
+            running.cancel();
+        }
+    }
+
+    /**
+     * Names a pack for a log line.
+     *
+     * @param definition the pack, or {@code null} when no season is served
+     * @return the pack identifier, or {@code none}
+     */
+    private static String identify(@Nullable ResourcePackDefinition definition) {
+        return definition == null ? "none" : definition.id().toString();
+    }
+}

--- a/common/src/main/java/net/onelitefeather/titan/common/resourcepack/ResourcePackService.java
+++ b/common/src/main/java/net/onelitefeather/titan/common/resourcepack/ResourcePackService.java
@@ -1,0 +1,317 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.common.resourcepack;
+
+import net.kyori.adventure.resource.ResourcePackStatus;
+import net.minestom.server.entity.Player;
+import net.theevilreaper.aves.resourcepack.ResourcePackCondition;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Delivers the lobby's resource pack stack and keeps track of what every player holds.
+ *
+ * <p>The model is one large base pack with an identifier that never changes plus a small season
+ * delta with an identifier of its own. A season change pops exactly the season identifier and
+ * pushes the new one; the base pack is never touched and stays in the client cache.
+ *
+ * <p>Four things this class exists to get right, all of them properties of Minestom or of the
+ * protocol rather than of Titan:
+ * <ol>
+ * <li>Packs are pushed one at a time and removed by identifier.
+ * {@code ResourcePackRequest#replace(true)} is never used, because Minestom implements it as
+ * pop-all-then-push: the client drops every pack and reloads twice.</li>
+ * <li>{@code ConnectionManager.doConfiguration()} calls {@code packFuture.join()} with no
+ * timeout before it sends {@code FinishConfigurationPacket}. A client that never answers parks
+ * that configuration thread forever, so every push arms {@linkplain #armTimeout a guard} that
+ * completes the future and lets the server proceed.</li>
+ * <li>Geyser answers on a Bedrock player's behalf and reports success for a pack the player
+ * never received. Bedrock players are therefore recognised up front and, by default, excluded
+ * from delivery; their reported status is never evaluated.</li>
+ * <li>Minestom tracks only the packs whose answer is still outstanding, never what a player
+ * holds, so the {@link HeldPackRegistry} keeps that book.</li>
+ * </ol>
+ *
+ * <p>With no pack configured the service is inert: every entry point returns without sending
+ * anything.
+ *
+ * @author TheMeinerLP
+ * @version 1.0.0
+ * @since 1.15.0
+ */
+public final class ResourcePackService implements AutoCloseable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResourcePackService.class);
+
+    private final HeldPackRegistry registry;
+    private final BedrockDetector bedrockDetector;
+    private final PackTimeoutScheduler timeoutScheduler;
+    private final Map<PackSlot, ResourcePackCondition> conditions = new EnumMap<>(PackSlot.class);
+    private volatile ResourcePackSettings settings;
+
+    /**
+     * Creates a service with explicit collaborators. Tests use this to substitute the detector
+     * and the scheduler.
+     *
+     * @param settings         the settings to start with
+     * @param registry         the book of packs the players hold
+     * @param bedrockDetector  recognises players whose reported status must be ignored
+     * @param timeoutScheduler runs the timeout guard
+     */
+    public ResourcePackService(ResourcePackSettings settings, HeldPackRegistry registry, BedrockDetector bedrockDetector, PackTimeoutScheduler timeoutScheduler) {
+        this.settings = Objects.requireNonNull(settings, "The resource pack settings must not be null");
+        this.registry = Objects.requireNonNull(registry, "The held pack registry must not be null");
+        this.bedrockDetector = Objects.requireNonNull(bedrockDetector, "The bedrock detector must not be null");
+        this.timeoutScheduler = Objects.requireNonNull(timeoutScheduler, "The timeout scheduler must not be null");
+    }
+
+    /**
+     * Creates the service Titan runs with: a fresh registry, Floodgate detection using the
+     * configured prefix and a daemon-thread timeout scheduler.
+     *
+     * @param settings the loaded settings
+     * @return the service
+     */
+    public static ResourcePackService create(ResourcePackSettings settings) {
+        return new ResourcePackService(settings, new HeldPackRegistry(), BedrockDetector.floodgate(settings.bedrockNamePrefix()), new DaemonPackTimeoutScheduler());
+    }
+
+    /**
+     * Registers what should happen when a client reports a terminal status for a slot - for
+     * instance a message on a failed download, or a kick when a required pack is declined.
+     *
+     * <p>The condition is Aves' {@link ResourcePackCondition}. It receives no pack identifier, so
+     * one condition is registered per slot and this service routes the report to the right one.
+     *
+     * @param slot      the slot the condition applies to
+     * @param condition the condition to run
+     * @return this service
+     */
+    public ResourcePackService withCondition(PackSlot slot, ResourcePackCondition condition) {
+        this.conditions.put(slot, condition);
+        return this;
+    }
+
+    /**
+     * The settings currently in effect.
+     *
+     * @return the settings
+     */
+    public ResourcePackSettings settings() {
+        return this.settings;
+    }
+
+    /**
+     * Whether any pack is configured. When this is {@code false} the lobby behaves exactly as a
+     * lobby without the feature: no listener needs registering and nothing is ever sent.
+     *
+     * @return {@code true} when at least one pack is configured
+     */
+    public boolean enabled() {
+        return this.settings.enabled();
+    }
+
+    /**
+     * The book of packs the players hold.
+     *
+     * @return the registry
+     */
+    public HeldPackRegistry registry() {
+        return this.registry;
+    }
+
+    /**
+     * Pushes every configured pack the player does not already hold. Called from the
+     * configuration phase, so the client downloads before it reaches the world.
+     *
+     * @param player the player entering configuration
+     */
+    public void onConfiguration(Player player) {
+        ResourcePackSettings current = this.settings;
+        if (!current.enabled()) {
+            return;
+        }
+        boolean bedrock = this.bedrockDetector.isBedrock(player);
+        if (bedrock && !current.sendToBedrockPlayers()) {
+            LOGGER.debug("Skipping resource packs for the bedrock player {} - geyser would report success without delivering anything", player.getUsername());
+            return;
+        }
+        boolean pushed = false;
+        for (PackSlot slot : PackSlot.values()) {
+            pushed |= this.push(player, slot, current.packFor(slot), bedrock);
+        }
+        if (pushed) {
+            this.armTimeout(player, current.responseTimeout());
+        }
+    }
+
+    /**
+     * Replaces the season pack for every player who is online, and for everyone who joins from
+     * now on.
+     *
+     * <p>Only the season identifier is popped. The base pack is never removed, so the client
+     * keeps it cached and reloads just the small delta.
+     *
+     * @param season  the new season pack, or {@code null} to end the season without a successor
+     * @param players the players currently online
+     */
+    public void applySeason(@Nullable ResourcePackDefinition season, Collection<Player> players) {
+        ResourcePackSettings current = this.settings.withSeason(season);
+        this.settings = current;
+        for (Player player : players) {
+            UUID playerId = player.getUuid();
+            boolean bedrock = this.bedrockDetector.isBedrock(player);
+            if (bedrock && !current.sendToBedrockPlayers()) {
+                continue;
+            }
+            Optional<HeldPackRegistry.Entry> held = this.registry.entry(playerId, PackSlot.SEASON);
+            if (held.isPresent() && (season == null || !held.get().packId().equals(season.id()))) {
+                player.removeResourcePacks(held.get().packId());
+                this.registry.forget(playerId, PackSlot.SEASON);
+            }
+            if (this.push(player, PackSlot.SEASON, season, bedrock)) {
+                this.armTimeout(player, current.responseTimeout());
+            }
+        }
+    }
+
+    /**
+     * Handles a client's answer to a pushed pack.
+     *
+     * <p>Reports from Bedrock players are dropped without being looked at: Geyser sends them on
+     * the player's behalf and they say nothing about what the client actually has.
+     *
+     * @param player the player who answered
+     * @param packId the pack the answer is about
+     * @param status the reported status
+     */
+    public void onStatus(Player player, UUID packId, ResourcePackStatus status) {
+        if (this.bedrockDetector.isBedrock(player)) {
+            LOGGER.debug("Ignoring the reported pack status {} from the bedrock player {} - geyser answers on their behalf", status, player.getUsername());
+            return;
+        }
+        UUID playerId = player.getUuid();
+        PackSlot slot = this.registry.slotOf(playerId, packId);
+        if (slot == null) {
+            return;
+        }
+        if (status.intermediate()) {
+            return;
+        }
+        if (status == ResourcePackStatus.SUCCESSFULLY_LOADED) {
+            this.registry.confirm(playerId, slot);
+        } else {
+            this.registry.forget(playerId, slot);
+        }
+        ResourcePackCondition condition = this.conditions.get(slot);
+        if (condition != null) {
+            condition.handleStatus(player, status);
+        }
+    }
+
+    /**
+     * Drops everything remembered about a player.
+     *
+     * @param playerId the player who left
+     */
+    public void onDisconnect(UUID playerId) {
+        this.registry.forget(playerId);
+    }
+
+    /**
+     * Pushes one pack, unless it is not configured or the player already holds it.
+     *
+     * @param player     the receiving player
+     * @param slot       the slot being filled
+     * @param definition the pack to push, or {@code null} when that slot is not served
+     * @param bedrock    whether the receiver is a Bedrock player
+     * @return {@code true} when a push packet was sent
+     */
+    private boolean push(Player player, PackSlot slot, @Nullable ResourcePackDefinition definition, boolean bedrock) {
+        if (definition == null) {
+            return false;
+        }
+        UUID playerId = player.getUuid();
+        if (this.registry.holds(playerId, slot, definition.id())) {
+            return false;
+        }
+        // A required pack makes Minestom kick on any terminal status other than success. For a
+        // bedrock player that verdict would rest on Geyser's invented answer, so the requirement
+        // is dropped for them.
+        boolean required = definition.required() && !bedrock;
+        player.sendResourcePacks(definition.toRequest(required));
+        this.registry.markSent(playerId, slot, definition.id());
+        return true;
+    }
+
+    /**
+     * Arms the guard against a client that never answers.
+     *
+     * <p>{@code ConnectionManager.doConfiguration()} joins the player's pack future without a
+     * timeout, so nothing else can unblock that thread. The guard completes the future itself
+     * once the configured time has passed; configuration then continues and the player enters
+     * the lobby without the pack, which is the outcome the requirement asks for. A late answer
+     * from the client is still processed afterwards - it just no longer holds anything up.
+     *
+     * @param player  the player that was pushed to
+     * @param timeout how long to wait; a non-positive value disables the guard
+     */
+    private void armTimeout(Player player, Duration timeout) {
+        if (timeout.isZero() || timeout.isNegative()) {
+            return;
+        }
+        this.timeoutScheduler.schedule(() -> this.expireTimeout(player), timeout);
+    }
+
+    /**
+     * Completes the player's pending pack future so a parked configuration thread proceeds.
+     *
+     * @param player the player whose future is released
+     */
+    private void expireTimeout(Player player) {
+        CompletableFuture<Void> future = player.getResourcePackFuture();
+        if (future == null || future.isDone()) {
+            return;
+        }
+        LOGGER.warn("{} did not answer the resource pack request in time - continuing without it", player.getUsername());
+        future.complete(null);
+    }
+
+    /**
+     * Releases the timeout scheduler when the lobby shuts down.
+     */
+    @Override
+    public void close() {
+        if (this.timeoutScheduler instanceof AutoCloseable closeable) {
+            try {
+                closeable.close();
+            } catch (Exception exception) {
+                LOGGER.warn("Unable to stop the resource pack timeout scheduler", exception);
+            }
+        }
+    }
+}

--- a/common/src/main/java/net/onelitefeather/titan/common/resourcepack/ResourcePackService.java
+++ b/common/src/main/java/net/onelitefeather/titan/common/resourcepack/ResourcePackService.java
@@ -18,6 +18,7 @@ package net.onelitefeather.titan.common.resourcepack;
 
 import net.kyori.adventure.resource.ResourcePackStatus;
 import net.minestom.server.entity.Player;
+import net.onelitefeather.titan.common.utils.TitanFeatures;
 import net.theevilreaper.aves.resourcepack.ResourcePackCondition;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -33,6 +34,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BooleanSupplier;
 
 /**
  * Delivers the lobby's resource pack stack and keeps track of what every player holds.
@@ -61,6 +63,11 @@ import java.util.concurrent.CompletableFuture;
  * <p>With no pack configured the service is inert: every entry point returns without sending
  * anything.
  *
+ * <p>Whether a pack configured {@code required} is enforced - the client being disconnected
+ * when it declines the pack or lets the timeout run out - is not fixed in code. It is the flag
+ * {@link TitanFeatures#RESOURCE_PACK_REQUIRED_KICK}, enforced by default and read once per
+ * push.
+ *
  * @author TheMeinerLP
  * @version 1.0.0
  * @since 1.15.0
@@ -69,15 +76,23 @@ public final class ResourcePackService implements AutoCloseable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ResourcePackService.class);
 
+    /**
+     * The answer used when no gate is wired in: a pack configured {@code required} is enforced.
+     * This is the same direction {@link TitanFeatures#RESOURCE_PACK_REQUIRED_KICK} defaults to,
+     * so a service built without a gate behaves like one whose flag was never written.
+     */
+    private static final BooleanSupplier ENFORCE_REQUIRED_PACKS = () -> true;
+
     private final HeldPackRegistry registry;
     private final BedrockDetector bedrockDetector;
     private final PackTimeoutScheduler timeoutScheduler;
+    private final BooleanSupplier requiredPackKick;
     private final Map<PackSlot, ResourcePackCondition> conditions = new EnumMap<>(PackSlot.class);
     private volatile ResourcePackSettings settings;
 
     /**
-     * Creates a service with explicit collaborators. Tests use this to substitute the detector
-     * and the scheduler.
+     * Creates a service with explicit collaborators that always enforces a required pack. Tests
+     * use this to substitute the detector and the scheduler.
      *
      * @param settings         the settings to start with
      * @param registry         the book of packs the players hold
@@ -85,21 +100,38 @@ public final class ResourcePackService implements AutoCloseable {
      * @param timeoutScheduler runs the timeout guard
      */
     public ResourcePackService(ResourcePackSettings settings, HeldPackRegistry registry, BedrockDetector bedrockDetector, PackTimeoutScheduler timeoutScheduler) {
+        this(settings, registry, bedrockDetector, timeoutScheduler, ENFORCE_REQUIRED_PACKS);
+    }
+
+    /**
+     * Creates a service with explicit collaborators, the enforcement of required packs included.
+     *
+     * @param settings         the settings to start with
+     * @param registry         the book of packs the players hold
+     * @param bedrockDetector  recognises players whose reported status must be ignored
+     * @param timeoutScheduler runs the timeout guard
+     * @param requiredPackKick whether a pack configured {@code required} is enforced right now;
+     *                         asked once per push, see
+     *                         {@link TitanFeatures#RESOURCE_PACK_REQUIRED_KICK}
+     */
+    public ResourcePackService(ResourcePackSettings settings, HeldPackRegistry registry, BedrockDetector bedrockDetector, PackTimeoutScheduler timeoutScheduler, BooleanSupplier requiredPackKick) {
         this.settings = Objects.requireNonNull(settings, "The resource pack settings must not be null");
         this.registry = Objects.requireNonNull(registry, "The held pack registry must not be null");
         this.bedrockDetector = Objects.requireNonNull(bedrockDetector, "The bedrock detector must not be null");
         this.timeoutScheduler = Objects.requireNonNull(timeoutScheduler, "The timeout scheduler must not be null");
+        this.requiredPackKick = Objects.requireNonNull(requiredPackKick, "The required pack kick switch must not be null");
     }
 
     /**
      * Creates the service Titan runs with: a fresh registry, Floodgate detection using the
-     * configured prefix and a daemon-thread timeout scheduler.
+     * configured prefix, a daemon-thread timeout scheduler and the enforcement of required packs
+     * read from {@link TitanFeatures#RESOURCE_PACK_REQUIRED_KICK}.
      *
      * @param settings the loaded settings
      * @return the service
      */
     public static ResourcePackService create(ResourcePackSettings settings) {
-        return new ResourcePackService(settings, new HeldPackRegistry(), BedrockDetector.floodgate(settings.bedrockNamePrefix()), new DaemonPackTimeoutScheduler());
+        return new ResourcePackService(settings, new HeldPackRegistry(), BedrockDetector.floodgate(settings.bedrockNamePrefix()), new DaemonPackTimeoutScheduler(), TitanFeatures.RESOURCE_PACK_REQUIRED_KICK::isActive);
     }
 
     /**
@@ -262,10 +294,12 @@ public final class ResourcePackService implements AutoCloseable {
         if (this.registry.holds(playerId, slot, definition.id())) {
             return false;
         }
-        // A required pack makes Minestom kick on any terminal status other than success. For a
-        // bedrock player that verdict would rest on Geyser's invented answer, so the requirement
-        // is dropped for them.
-        boolean required = definition.required() && !bedrock;
+        // A required pack makes Minestom kick on any terminal status other than success. Two
+        // things soften that requirement, and both have to be decided here rather than when the
+        // answer arrives, because Minestom stores the bit at push time and reads it back later.
+        // For a bedrock player the verdict would rest on Geyser's invented answer. And
+        // RESOURCE_PACK_REQUIRED_KICK is the operator's switch for the behaviour as a whole.
+        boolean required = definition.required() && !bedrock && this.requiredPackKick.getAsBoolean();
         player.sendResourcePacks(definition.toRequest(required));
         this.registry.markSent(playerId, slot, definition.id());
         return true;
@@ -317,7 +351,10 @@ public final class ResourcePackService implements AutoCloseable {
      *
      * <p>Note that this makes Minestom kick a player whose <em>required</em> pack timed out,
      * exactly as it does for any other terminal status on a required pack. That is the meaning
-     * of {@code required}, and it is the only outcome that leaves no half-state behind.
+     * of {@code required}, and it is the only outcome that leaves no half-state behind. Whether
+     * a pack was pushed as required at all is decided in {@link #push} from
+     * {@link TitanFeatures#RESOURCE_PACK_REQUIRED_KICK}; with that flag inactive the same
+     * answer is given, the same bookkeeping is cleaned up and nobody is disconnected.
      *
      * @param player  the player whose request is released
      * @param future  the future that was outstanding when the guard was armed

--- a/common/src/main/java/net/onelitefeather/titan/common/resourcepack/ResourcePackService.java
+++ b/common/src/main/java/net/onelitefeather/titan/common/resourcepack/ResourcePackService.java
@@ -24,8 +24,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -47,8 +49,8 @@ import java.util.concurrent.CompletableFuture;
  * pop-all-then-push: the client drops every pack and reloads twice.</li>
  * <li>{@code ConnectionManager.doConfiguration()} calls {@code packFuture.join()} with no
  * timeout before it sends {@code FinishConfigurationPacket}. A client that never answers parks
- * that configuration thread forever, so every push arms {@linkplain #armTimeout a guard} that
- * completes the future and lets the server proceed.</li>
+ * that configuration thread forever, so every push arms {@linkplain #armTimeout a guard} bound
+ * to that request which answers on the client's behalf and lets the server proceed.</li>
  * <li>Geyser answers on a Bedrock player's behalf and reports success for a pack the player
  * never received. Bedrock players are therefore recognised up front and, by default, excluded
  * from delivery; their reported status is never evaluated.</li>
@@ -160,13 +162,14 @@ public final class ResourcePackService implements AutoCloseable {
             LOGGER.debug("Skipping resource packs for the bedrock player {} - geyser would report success without delivering anything", player.getUsername());
             return;
         }
-        boolean pushed = false;
+        List<UUID> pushed = new ArrayList<>(PackSlot.values().length);
         for (PackSlot slot : PackSlot.values()) {
-            pushed |= this.push(player, slot, current.packFor(slot), bedrock);
+            ResourcePackDefinition definition = current.packFor(slot);
+            if (this.push(player, slot, definition, bedrock)) {
+                pushed.add(definition.id());
+            }
         }
-        if (pushed) {
-            this.armTimeout(player, current.responseTimeout());
-        }
+        this.armTimeout(player, current.responseTimeout(), pushed);
     }
 
     /**
@@ -194,7 +197,7 @@ public final class ResourcePackService implements AutoCloseable {
                 this.registry.forget(playerId, PackSlot.SEASON);
             }
             if (this.push(player, PackSlot.SEASON, season, bedrock)) {
-                this.armTimeout(player, current.responseTimeout());
+                this.armTimeout(player, current.responseTimeout(), List.of(season.id()));
             }
         }
     }
@@ -272,33 +275,74 @@ public final class ResourcePackService implements AutoCloseable {
      * Arms the guard against a client that never answers.
      *
      * <p>{@code ConnectionManager.doConfiguration()} joins the player's pack future without a
-     * timeout, so nothing else can unblock that thread. The guard completes the future itself
-     * once the configured time has passed; configuration then continues and the player enters
-     * the lobby without the pack, which is the outcome the requirement asks for. A late answer
-     * from the client is still processed afterwards - it just no longer holds anything up.
+     * timeout, so nothing else can unblock that thread. The guard releases it once the
+     * configured time has passed; configuration then continues and a late answer from the
+     * client is still processed afterwards - it just no longer holds anything up.
+     *
+     * <p>The guard is bound to the request it was armed for: it captures the exact future that
+     * is outstanding right now, together with the packs this request pushed. Without that
+     * binding a queued guard would later fetch <em>whatever</em> future the player happens to
+     * have and release a request the client has not answered yet.
      *
      * @param player  the player that was pushed to
      * @param timeout how long to wait; a non-positive value disables the guard
+     * @param packIds the packs this request pushed; empty means nothing was sent
      */
-    private void armTimeout(Player player, Duration timeout) {
-        if (timeout.isZero() || timeout.isNegative()) {
+    private void armTimeout(Player player, Duration timeout, List<UUID> packIds) {
+        if (packIds.isEmpty() || timeout.isZero() || timeout.isNegative()) {
             return;
         }
-        this.timeoutScheduler.schedule(() -> this.expireTimeout(player), timeout);
-    }
-
-    /**
-     * Completes the player's pending pack future so a parked configuration thread proceeds.
-     *
-     * @param player the player whose future is released
-     */
-    private void expireTimeout(Player player) {
         CompletableFuture<Void> future = player.getResourcePackFuture();
         if (future == null || future.isDone()) {
             return;
         }
+        this.timeoutScheduler.schedule(() -> this.expireTimeout(player, future, packIds), timeout);
+    }
+
+    /**
+     * Releases the request this guard was armed for, and only that one.
+     *
+     * <p>Completing the future from the outside is not enough. Minestom clears
+     * {@code Player#resourcePackFuture} only inside {@code onResourcePackStatus}, once every
+     * pending pack has answered; a future completed behind its back stays in the field forever.
+     * {@code sendResourcePacks} then finds a non-null future and never creates a new one, so
+     * every later configuration pass joins an already-completed future and stops waiting for
+     * packs altogether.
+     *
+     * <p>So the guard hands Minestom the terminal answer the silent client owes it, pack by
+     * pack. Minestom drops each pack from its pending map and, once that map runs empty,
+     * completes and clears the future itself - the same path a real answer takes, leaving no
+     * stale state behind. The status used is {@link ResourcePackStatus#DISCARDED}, which is what
+     * actually happened: the pack was never loaded.
+     *
+     * <p>Note that this makes Minestom kick a player whose <em>required</em> pack timed out,
+     * exactly as it does for any other terminal status on a required pack. That is the meaning
+     * of {@code required}, and it is the only outcome that leaves no half-state behind.
+     *
+     * @param player  the player whose request is released
+     * @param future  the future that was outstanding when the guard was armed
+     * @param packIds the packs that request pushed
+     */
+    private void expireTimeout(Player player, CompletableFuture<Void> future, List<UUID> packIds) {
+        if (future.isDone() || player.getResourcePackFuture() != future) {
+            // Either the client answered, or a newer request owns the player's future by now.
+            return;
+        }
         LOGGER.warn("{} did not answer the resource pack request in time - continuing without it", player.getUsername());
-        future.complete(null);
+        UUID playerId = player.getUuid();
+        for (UUID packId : packIds) {
+            PackSlot slot = this.registry.slotOf(playerId, packId);
+            if (slot != null) {
+                this.registry.forget(playerId, slot);
+            }
+            player.onResourcePackStatus(packId, ResourcePackStatus.DISCARDED);
+        }
+        if (!future.isDone()) {
+            // A pack from outside this request is still pending, so Minestom did not release the
+            // future. The configuration thread must not stay parked for it either.
+            LOGGER.warn("Releasing the pack future of {} with packs from an earlier request still pending", player.getUsername());
+            future.complete(null);
+        }
     }
 
     /**

--- a/common/src/main/java/net/onelitefeather/titan/common/resourcepack/ResourcePackSettings.java
+++ b/common/src/main/java/net/onelitefeather/titan/common/resourcepack/ResourcePackSettings.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.common.resourcepack;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Duration;
+
+/**
+ * Everything the lobby needs to deliver resource packs, as it is read from
+ * {@code resource-packs.json}.
+ *
+ * <p>Both packs are optional. With neither configured the settings are
+ * {@linkplain #enabled() disabled} and nothing is ever pushed - that is the state of a lobby
+ * without a pack server, and it must stay indistinguishable from a lobby that never knew about
+ * resource packs.
+ *
+ * @param base                  the long-lived base pack, or {@code null} when none is served
+ * @param season                the current season delta pack, or {@code null} when none is served
+ * @param responseTimeoutMillis how long to wait for a client's answer before continuing;
+ *                              {@code 0} (or absent) selects {@link #DEFAULT_RESPONSE_TIMEOUT},
+ *                              a negative value disables the guard
+ * @param sendToBedrockPlayers  whether Bedrock players receive the packs at all; defaults to
+ *                              {@code false}, because Geyser reports success for packs the
+ *                              player never received
+ * @param bedrockNamePrefix     the Floodgate name prefix used to recognise Bedrock players;
+ *                              {@code null} selects {@link #DEFAULT_BEDROCK_NAME_PREFIX}, an
+ *                              empty string disables prefix matching
+ * @author TheMeinerLP
+ * @version 1.0.0
+ * @since 1.15.0
+ */
+public record ResourcePackSettings(@Nullable ResourcePackDefinition base,
+                                   @Nullable ResourcePackDefinition season,
+                                   long responseTimeoutMillis,
+                                   boolean sendToBedrockPlayers, String bedrockNamePrefix) {
+
+    /** Applied when the configuration leaves the timeout unset. */
+    public static final Duration DEFAULT_RESPONSE_TIMEOUT = Duration.ofSeconds(10);
+
+    /** Floodgate's default prefix for Bedrock player names. */
+    public static final String DEFAULT_BEDROCK_NAME_PREFIX = ".";
+
+    private static final ResourcePackSettings DISABLED = new ResourcePackSettings(null, null, 0L, false, DEFAULT_BEDROCK_NAME_PREFIX);
+
+    /**
+     * Fills in the defaults for values a configuration file may legitimately omit.
+     */
+    public ResourcePackSettings {
+        if (responseTimeoutMillis == 0L) {
+            responseTimeoutMillis = DEFAULT_RESPONSE_TIMEOUT.toMillis();
+        }
+        if (bedrockNamePrefix == null) {
+            bedrockNamePrefix = DEFAULT_BEDROCK_NAME_PREFIX;
+        }
+    }
+
+    /**
+     * The settings of a lobby without any configured pack: nothing is delivered.
+     *
+     * @return settings that make the whole feature inert
+     */
+    public static ResourcePackSettings disabled() {
+        return DISABLED;
+    }
+
+    /**
+     * Whether any pack is configured at all.
+     *
+     * @return {@code true} when at least one pack would be delivered
+     */
+    public boolean enabled() {
+        return this.base != null || this.season != null;
+    }
+
+    /**
+     * The pack configured for a slot.
+     *
+     * @param slot the slot to look up
+     * @return the pack, or {@code null} when that slot is not served
+     */
+    public @Nullable ResourcePackDefinition packFor(PackSlot slot) {
+        return switch (slot) {
+            case BASE -> this.base;
+            case SEASON -> this.season;
+        };
+    }
+
+    /**
+     * How long a client may take to answer a pack push before the lobby stops waiting.
+     *
+     * @return the timeout; {@linkplain Duration#isNegative() negative} when the guard is off
+     */
+    public Duration responseTimeout() {
+        return Duration.ofMillis(this.responseTimeoutMillis);
+    }
+
+    /**
+     * The same settings with a different season pack. Used when a season turns; the base pack
+     * and every other value stay untouched.
+     *
+     * @param season the new season pack, or {@code null} to serve none
+     * @return the updated settings
+     */
+    public ResourcePackSettings withSeason(@Nullable ResourcePackDefinition season) {
+        return new ResourcePackSettings(this.base, season, this.responseTimeoutMillis, this.sendToBedrockPlayers, this.bedrockNamePrefix);
+    }
+}

--- a/common/src/main/java/net/onelitefeather/titan/common/resourcepack/ResourcePackSettingsProvider.java
+++ b/common/src/main/java/net/onelitefeather/titan/common/resourcepack/ResourcePackSettingsProvider.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.common.resourcepack;
+
+import com.google.gson.reflect.TypeToken;
+import net.theevilreaper.aves.file.ModernGsonFileHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * Reads {@code resource-packs.json} next to the server and turns it into
+ * {@link ResourcePackSettings}.
+ *
+ * <p>A missing file is the normal case and not an error: it yields
+ * {@link ResourcePackSettings#disabled()}, and nothing is written to disk. A malformed file is
+ * reported and also yields disabled settings, so a typo in the configuration cannot keep players
+ * out of the lobby.
+ *
+ * @author TheMeinerLP
+ * @version 1.0.0
+ * @since 1.15.0
+ */
+public final class ResourcePackSettingsProvider {
+
+    /** Name of the configuration file, resolved against the server directory. */
+    public static final String FILE_NAME = "resource-packs.json";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResourcePackSettingsProvider.class);
+    private static final TypeToken<ResourcePackSettings> TYPE = TypeToken.get(ResourcePackSettings.class);
+
+    private ResourcePackSettingsProvider() {
+    }
+
+    /**
+     * Loads the settings from {@code <directory>/resource-packs.json}.
+     *
+     * @param directory the directory the server runs in
+     * @return the configured settings, or {@link ResourcePackSettings#disabled()} when the file
+     *         is absent or cannot be read
+     */
+    public static ResourcePackSettings load(Path directory) {
+        Path file = directory.resolve(FILE_NAME);
+        ResourcePackSettings settings;
+        try {
+            Optional<ResourcePackSettings> loaded = new ModernGsonFileHandler().load(file, TYPE);
+            settings = loaded.orElse(null);
+        } catch (RuntimeException exception) {
+            LOGGER.warn("Unable to read {} - resource packs stay disabled", file, exception);
+            return ResourcePackSettings.disabled();
+        }
+        if (settings == null) {
+            LOGGER.debug("No {} found - resource packs stay disabled", file);
+            return ResourcePackSettings.disabled();
+        }
+        if (!settings.enabled()) {
+            LOGGER.info("{} configures no pack - resource packs stay disabled", file);
+            return settings;
+        }
+        warnAboutCaching(settings);
+        return settings;
+    }
+
+    /**
+     * Logs a warning for every configured pack whose URL does not carry its hash. The client
+     * caches downloaded packs by URL, so a pack served from a fixed URL is never re-downloaded
+     * after its content changed.
+     *
+     * @param settings the settings to check
+     */
+    private static void warnAboutCaching(ResourcePackSettings settings) {
+        for (PackSlot slot : PackSlot.values()) {
+            ResourcePackDefinition definition = settings.packFor(slot);
+            if (definition != null && !definition.contentAddressed()) {
+                LOGGER.warn("The {} pack url does not contain its sha1 ({}). Clients cache packs by url, not by hash - serve it as pack-<sha1>.zip or changes will not reach players who already downloaded it.", slot, definition.url());
+            }
+        }
+    }
+}

--- a/common/src/main/java/net/onelitefeather/titan/common/resourcepack/ResourcePackSettingsProvider.java
+++ b/common/src/main/java/net/onelitefeather/titan/common/resourcepack/ResourcePackSettingsProvider.java
@@ -56,25 +56,40 @@ public final class ResourcePackSettingsProvider {
      *         is absent or cannot be read
      */
     public static ResourcePackSettings load(Path directory) {
+        return reload(directory).orElseGet(ResourcePackSettings::disabled);
+    }
+
+    /**
+     * Reads the settings and reports whether the file could be read at all.
+     *
+     * <p>{@link #load(Path)} cannot tell "the operator configured no pack" from "the file is
+     * missing or broken" - both end up disabled. A reload has to tell them apart: a lobby that
+     * is already serving packs must not strip them from every player because someone saved a
+     * half-written file. So an absent or unreadable file yields an empty result here, and only
+     * a file that actually parsed yields settings - even when those settings configure nothing.
+     *
+     * @param directory the directory the server runs in
+     * @return the parsed settings, or empty when the file is absent or cannot be read
+     */
+    public static Optional<ResourcePackSettings> reload(Path directory) {
         Path file = directory.resolve(FILE_NAME);
         ResourcePackSettings settings;
         try {
-            Optional<ResourcePackSettings> loaded = new ModernGsonFileHandler().load(file, TYPE);
-            settings = loaded.orElse(null);
+            settings = new ModernGsonFileHandler().load(file, TYPE).orElse(null);
         } catch (RuntimeException exception) {
-            LOGGER.warn("Unable to read {} - resource packs stay disabled", file, exception);
-            return ResourcePackSettings.disabled();
+            LOGGER.warn("Unable to read {} - keeping the resource packs that are in effect", file, exception);
+            return Optional.empty();
         }
         if (settings == null) {
-            LOGGER.debug("No {} found - resource packs stay disabled", file);
-            return ResourcePackSettings.disabled();
+            LOGGER.debug("No {} found - keeping the resource packs that are in effect", file);
+            return Optional.empty();
         }
         if (!settings.enabled()) {
-            LOGGER.info("{} configures no pack - resource packs stay disabled", file);
-            return settings;
+            LOGGER.info("{} configures no pack", file);
+            return Optional.of(settings);
         }
         warnAboutCaching(settings);
-        return settings;
+        return Optional.of(settings);
     }
 
     /**

--- a/common/src/main/java/net/onelitefeather/titan/common/resourcepack/package-info.java
+++ b/common/src/main/java/net/onelitefeather/titan/common/resourcepack/package-info.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+/**
+ * Delivery of stacked resource packs: one long-lived base pack plus a swappable
+ * season pack, each with its own stable identifier.
+ *
+ * <p>The whole package is inert until a {@code resource-packs.json} is present -
+ * without it the lobby sends no resource pack packet at all.
+ *
+ * @author TheMeinerLP
+ * @version 1.0.0
+ * @since 1.15.0
+ */
+@NotNullByDefault
+package net.onelitefeather.titan.common.resourcepack;
+
+import org.jetbrains.annotations.NotNullByDefault;

--- a/common/src/main/java/net/onelitefeather/titan/common/utils/TitanFeatures.java
+++ b/common/src/main/java/net/onelitefeather/titan/common/utils/TitanFeatures.java
@@ -17,10 +17,67 @@
 package net.onelitefeather.titan.common.utils;
 
 import org.togglz.core.Feature;
+import org.togglz.core.annotation.EnabledByDefault;
 import org.togglz.core.context.FeatureContext;
 
+/**
+ * Every flag Titan reads from {@code flags.properties}.
+ *
+ * <p>Most of these are visibility flags: they decide whether a player is shown a navigator
+ * entry. {@link #RESOURCE_PACK_REQUIRED_KICK} is not one of them - it switches a
+ * <em>behaviour</em> on and off for the whole lobby and is documented as such on the constant
+ * itself.
+ *
+ * <p>NFR-009 caps this enum at twelve constants. A flag that only ever has one value in
+ * production does not belong here.
+ *
+ * @author TheMeinerLP
+ * @version 1.0.0
+ * @since 1.15.0
+ */
 public enum TitanFeatures implements Feature, ThreadHelper {
-    NAVIGATOR_CREATIVE, NAVIGATOR_SLENDER, NAVIGATOR_MANIS, NAVIGATOR_SURVIVAL, NAVIGATOR_ELYTRA,;
+
+    NAVIGATOR_CREATIVE, NAVIGATOR_SLENDER, NAVIGATOR_MANIS, NAVIGATOR_SURVIVAL, NAVIGATOR_ELYTRA,
+
+    /**
+     * Whether a resource pack configured {@code "required": true} is actually enforced, meaning
+     * the lobby disconnects a client that does not load it.
+     *
+     * <p>This is a server-wide switch for a behaviour, not a question about who may see
+     * something. It is therefore read as a plain kill switch: only the enabled/disabled bit of
+     * the flag is consulted, never a release stage and never the player's permissions. Two
+     * reasons for that. A stage would mean the same silent client is disconnected or admitted
+     * depending on which group it belongs to, which is not something an operator can reason
+     * about while an incident is running. And the population a stage would test the kick on
+     * first - the team - is the least representative sample there is for the question this
+     * behaviour actually raises, namely whether ordinary clients on ordinary connections manage
+     * to download the pack in time.
+     *
+     * <p><b>Active</b> (the default, see {@link EnabledByDefault}): the pack is pushed with the
+     * {@code forced} bit set, so the client shows the "you must accept this pack" dialog and
+     * Minestom disconnects it on any terminal answer other than success. That includes the
+     * {@code DISCARDED} answer the timeout guard gives on behalf of a client that never
+     * answered at all.
+     *
+     * <p><b>Inactive</b>: the very same pack is pushed as optional. Nothing about the pack
+     * changes except that neither a declined download nor an expired timeout costs the player
+     * their session; they reach the lobby without the pack.
+     *
+     * <p>The flag deliberately covers both terminal answers rather than the timeout alone.
+     * Minestom stores the {@code required} bit when the pack is pushed and consults it when the
+     * answer arrives, so there is no supported way to enforce a pack against a decline but not
+     * against a timeout - and a lobby that showed a forced-pack dialog it does not back up
+     * would mislead the player as much as it would the operator.
+     *
+     * <p>The default is active, so a lobby with no {@code flags.properties} - or one whose file
+     * cannot be read - behaves exactly as it did before this flag existed and keeps the promise
+     * an operator made by writing {@code "required": true}. Failing the other way would silently
+     * downgrade an explicit configuration to a suggestion. A kick is also the recoverable
+     * outcome of the two: the player reconnects and tries again, whereas a lobby that quietly
+     * stops enforcing its pack is a state nobody notices until the textures are wrong for
+     * everyone.
+     */
+    @EnabledByDefault RESOURCE_PACK_REQUIRED_KICK,;
 
     @Override
     public boolean isActive() {

--- a/common/src/test/java/net/onelitefeather/titan/common/resourcepack/FloodgateBedrockDetectorTest.java
+++ b/common/src/test/java/net/onelitefeather/titan/common/resourcepack/FloodgateBedrockDetectorTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.common.resourcepack;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FloodgateBedrockDetectorTest {
+
+    private final BedrockDetector detector = BedrockDetector.floodgate(ResourcePackSettings.DEFAULT_BEDROCK_NAME_PREFIX);
+
+    @Test
+    @DisplayName("A floodgate id has an all zero upper half")
+    void testFloodgateId() {
+        UUID floodgateId = new UUID(0L, 2535423272292734L);
+
+        assertTrue(this.detector.isBedrock(floodgateId, "Steve"));
+    }
+
+    @Test
+    @DisplayName("An online mode id is not bedrock")
+    void testOnlineModeId() {
+        UUID online = UUID.fromString("069a79f4-44e9-4726-a5be-fca90e38aaf5");
+
+        assertFalse(this.detector.isBedrock(online, "Notch"));
+    }
+
+    @Test
+    @DisplayName("An offline mode id is not bedrock either, it keeps its version nibble")
+    void testOfflineModeId() {
+        UUID offline = UUID.nameUUIDFromBytes("OfflinePlayer:Steve".getBytes(StandardCharsets.UTF_8));
+
+        assertFalse(this.detector.isBedrock(offline, "Steve"));
+    }
+
+    @Test
+    @DisplayName("The floodgate name prefix is recognised when the proxy already resolved the id")
+    void testNamePrefix() {
+        assertTrue(this.detector.isBedrock(UUID.randomUUID(), ".BedrockPlayer"));
+        assertFalse(this.detector.isBedrock(UUID.randomUUID(), "JavaPlayer"));
+    }
+
+    @Test
+    @DisplayName("An empty prefix leaves only the id check")
+    void testEmptyPrefix() {
+        BedrockDetector idOnly = BedrockDetector.floodgate("");
+
+        assertFalse(idOnly.isBedrock(UUID.randomUUID(), ".BedrockPlayer"));
+        assertTrue(idOnly.isBedrock(new UUID(0L, 42L), ".BedrockPlayer"));
+    }
+
+    @Test
+    @DisplayName("The never detector treats everyone as java")
+    void testNeverDetector() {
+        assertFalse(BedrockDetector.never().isBedrock(new UUID(0L, 42L), ".BedrockPlayer"));
+    }
+}

--- a/common/src/test/java/net/onelitefeather/titan/common/resourcepack/HeldPackRegistryTest.java
+++ b/common/src/test/java/net/onelitefeather/titan/common/resourcepack/HeldPackRegistryTest.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.common.resourcepack;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HeldPackRegistryTest {
+
+    private final HeldPackRegistry registry = new HeldPackRegistry();
+    private final UUID player = UUID.randomUUID();
+    private final UUID basePack = UUID.randomUUID();
+    private final UUID seasonPack = UUID.randomUUID();
+
+    @Test
+    @DisplayName("A pushed pack counts as held before the client answered")
+    void testPushedPackIsHeld() {
+        this.registry.markSent(this.player, PackSlot.BASE, this.basePack);
+
+        assertTrue(this.registry.holds(this.player, PackSlot.BASE, this.basePack));
+        assertFalse(this.registry.entry(this.player, PackSlot.BASE).orElseThrow().confirmed());
+    }
+
+    @Test
+    @DisplayName("A confirmed pack keeps its identifier")
+    void testConfirm() {
+        this.registry.markSent(this.player, PackSlot.SEASON, this.seasonPack);
+        this.registry.confirm(this.player, PackSlot.SEASON);
+
+        HeldPackRegistry.Entry entry = this.registry.entry(this.player, PackSlot.SEASON).orElseThrow();
+        assertEquals(this.seasonPack, entry.packId());
+        assertTrue(entry.confirmed());
+    }
+
+    @Test
+    @DisplayName("Slots are independent, forgetting the season leaves the base pack alone")
+    void testSlotsAreIndependent() {
+        this.registry.markSent(this.player, PackSlot.BASE, this.basePack);
+        this.registry.markSent(this.player, PackSlot.SEASON, this.seasonPack);
+
+        this.registry.forget(this.player, PackSlot.SEASON);
+
+        assertTrue(this.registry.holds(this.player, PackSlot.BASE, this.basePack));
+        assertTrue(this.registry.entry(this.player, PackSlot.SEASON).isEmpty());
+    }
+
+    @Test
+    @DisplayName("A status report is routed to a slot by its pack identifier")
+    void testSlotLookupByPackId() {
+        this.registry.markSent(this.player, PackSlot.BASE, this.basePack);
+        this.registry.markSent(this.player, PackSlot.SEASON, this.seasonPack);
+
+        assertEquals(PackSlot.BASE, this.registry.slotOf(this.player, this.basePack));
+        assertEquals(PackSlot.SEASON, this.registry.slotOf(this.player, this.seasonPack));
+        assertNull(this.registry.slotOf(this.player, UUID.randomUUID()));
+        assertNull(this.registry.slotOf(UUID.randomUUID(), this.basePack));
+    }
+
+    @Test
+    @DisplayName("A slot remembers the pack that was pushed, not the one that is configured now")
+    void testSlotKeepsTheOlderSeason() {
+        UUID lastYear = UUID.randomUUID();
+        this.registry.markSent(this.player, PackSlot.SEASON, lastYear);
+
+        UUID thisYear = UUID.randomUUID();
+        assertFalse(this.registry.holds(this.player, PackSlot.SEASON, thisYear));
+        assertEquals(lastYear, this.registry.entry(this.player, PackSlot.SEASON).orElseThrow().packId());
+    }
+
+    @Test
+    @DisplayName("A disconnect drops the whole player")
+    void testForgetPlayer() {
+        this.registry.markSent(this.player, PackSlot.BASE, this.basePack);
+        this.registry.markSent(this.player, PackSlot.SEASON, this.seasonPack);
+
+        this.registry.forget(this.player);
+
+        assertEquals(0, this.registry.trackedPlayers());
+        assertTrue(this.registry.entry(this.player, PackSlot.BASE).isEmpty());
+    }
+
+    @Test
+    @DisplayName("Forgetting the last slot drops the player as well, so the book cannot grow forever")
+    void testEmptyPlayerIsRemoved() {
+        this.registry.markSent(this.player, PackSlot.BASE, this.basePack);
+
+        this.registry.forget(this.player, PackSlot.BASE);
+
+        assertEquals(0, this.registry.trackedPlayers());
+    }
+}

--- a/common/src/test/java/net/onelitefeather/titan/common/resourcepack/PackFailureNoticeTest.java
+++ b/common/src/test/java/net/onelitefeather/titan/common/resourcepack/PackFailureNoticeTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.common.resourcepack;
+
+import net.kyori.adventure.resource.ResourcePackStatus;
+import net.minestom.server.entity.Player;
+import net.minestom.server.instance.Instance;
+import net.minestom.server.network.packet.server.play.SystemChatPacket;
+import net.minestom.testing.Collector;
+import net.minestom.testing.Env;
+import net.minestom.testing.TestConnection;
+import net.minestom.testing.extension.MicrotusExtension;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(MicrotusExtension.class)
+class PackFailureNoticeTest {
+
+    @Test
+    @DisplayName("A pack that could not be downloaded or loaded is reported to the player")
+    void testFailureIsReported(Env env) {
+        Instance instance = env.createFlatInstance();
+        TestConnection connection = env.createConnection();
+        Player player = connection.connect(instance);
+        Collector<SystemChatPacket> messages = connection.trackIncoming(SystemChatPacket.class);
+
+        PackFailureNotice notice = new PackFailureNotice(PackSlot.SEASON);
+        notice.handleStatus(player, ResourcePackStatus.FAILED_DOWNLOAD);
+        notice.handleStatus(player, ResourcePackStatus.INVALID_URL);
+        notice.handleStatus(player, ResourcePackStatus.FAILED_RELOAD);
+
+        messages.assertCount(3);
+    }
+
+    @Test
+    @DisplayName("A loaded pack and a declined pack are not worth a message")
+    void testSilentStatuses(Env env) {
+        Instance instance = env.createFlatInstance();
+        TestConnection connection = env.createConnection();
+        Player player = connection.connect(instance);
+        Collector<SystemChatPacket> messages = connection.trackIncoming(SystemChatPacket.class);
+
+        PackFailureNotice notice = new PackFailureNotice(PackSlot.BASE);
+        notice.handleStatus(player, ResourcePackStatus.SUCCESSFULLY_LOADED);
+        notice.handleStatus(player, ResourcePackStatus.DOWNLOADED);
+        // The player chose this, and for a required pack Minestom has already kicked them.
+        notice.handleStatus(player, ResourcePackStatus.DECLINED);
+
+        messages.assertEmpty();
+    }
+}

--- a/common/src/test/java/net/onelitefeather/titan/common/resourcepack/RequiredPackKickFlagTest.java
+++ b/common/src/test/java/net/onelitefeather/titan/common/resourcepack/RequiredPackKickFlagTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.common.resourcepack;
+
+import net.onelitefeather.titan.common.utils.TitanFeatures;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.togglz.core.manager.FeatureManager;
+import org.togglz.core.manager.FeatureManagerBuilder;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.repository.mem.InMemoryStateRepository;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the default of {@link TitanFeatures#RESOURCE_PACK_REQUIRED_KICK}. A lobby without a
+ * {@code flags.properties} - or with one that cannot be read - must enforce a pack the operator
+ * configured {@code required}, because the absence of a file is not a decision to stop
+ * enforcing.
+ */
+class RequiredPackKickFlagTest {
+
+    private static FeatureManager emptyRepository() {
+        return new FeatureManagerBuilder().featureEnum(TitanFeatures.class).stateRepository(new InMemoryStateRepository()).build();
+    }
+
+    @Test
+    @DisplayName("A missing flag file leaves required packs enforced")
+    void testDefaultsToEnforcing() {
+        assertTrue(emptyRepository().isActive(TitanFeatures.RESOURCE_PACK_REQUIRED_KICK), "Without a stored state the kick must stay on");
+    }
+
+    @Test
+    @DisplayName("The flag is a plain kill switch an operator can turn off")
+    void testCanBeSwitchedOff() {
+        FeatureManager manager = emptyRepository();
+        manager.setFeatureState(new FeatureState(TitanFeatures.RESOURCE_PACK_REQUIRED_KICK, false));
+        assertFalse(manager.isActive(TitanFeatures.RESOURCE_PACK_REQUIRED_KICK));
+    }
+}

--- a/common/src/test/java/net/onelitefeather/titan/common/resourcepack/ResourcePackDefinitionTest.java
+++ b/common/src/test/java/net/onelitefeather/titan/common/resourcepack/ResourcePackDefinitionTest.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.common.resourcepack;
+
+import net.kyori.adventure.resource.ResourcePackRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ResourcePackDefinitionTest {
+
+    private static final String HASH = "0123456789abcdef0123456789abcdef01234567";
+    private static final UUID ID = UUID.fromString("3ac1b0d9-4c8e-4d4a-9a05-cb2f0d5f9c7e");
+
+    @Test
+    @DisplayName("A definition keeps id, url and hash")
+    void testValidDefinition() {
+        ResourcePackDefinition definition = new ResourcePackDefinition(ID, "https://packs.example/pack-" + HASH + ".zip", HASH, true, null);
+
+        assertEquals(ID, definition.id());
+        assertEquals(HASH, definition.hash());
+        assertEquals("https://packs.example/pack-" + HASH + ".zip", definition.uri().toString());
+        assertTrue(definition.required());
+    }
+
+    @Test
+    @DisplayName("An uppercase hash is normalised, because the protocol field is compared lowercase")
+    void testHashIsNormalised() {
+        ResourcePackDefinition definition = new ResourcePackDefinition(ID, "https://packs.example/base.zip", "  " + HASH.toUpperCase(java.util.Locale.ROOT) + " ", false, null);
+
+        assertEquals(HASH, definition.hash());
+    }
+
+    @Test
+    @DisplayName("A missing or malformed hash is rejected, the client caches by url and needs it")
+    void testHashIsMandatory() {
+        assertThrows(NullPointerException.class, () -> new ResourcePackDefinition(ID, "https://packs.example/base.zip", null, false, null));
+        assertThrows(IllegalArgumentException.class, () -> new ResourcePackDefinition(ID, "https://packs.example/base.zip", "not-a-hash", false, null));
+        assertThrows(IllegalArgumentException.class, () -> new ResourcePackDefinition(ID, "https://packs.example/base.zip", HASH + "00", false, null));
+    }
+
+    @Test
+    @DisplayName("A blank or malformed url is rejected")
+    void testUrlIsValidated() {
+        assertThrows(IllegalArgumentException.class, () -> new ResourcePackDefinition(ID, "  ", HASH, false, null));
+        assertThrows(IllegalArgumentException.class, () -> new ResourcePackDefinition(ID, "https://packs.example/a pack.zip", HASH, false, null));
+    }
+
+    @Test
+    @DisplayName("Only a url carrying the hash survives the client's url keyed cache")
+    void testContentAddressedDetection() {
+        ResourcePackDefinition addressed = new ResourcePackDefinition(ID, "https://packs.example/pack-" + HASH + ".zip", HASH, false, null);
+        ResourcePackDefinition fixedName = new ResourcePackDefinition(ID, "https://packs.example/season.zip", HASH, false, null);
+
+        assertTrue(addressed.contentAddressed());
+        assertFalse(fixedName.contentAddressed());
+    }
+
+    @Test
+    @DisplayName("A request pushes a single pack and never replaces the stack")
+    void testRequestNeverReplaces() {
+        ResourcePackDefinition definition = new ResourcePackDefinition(ID, "https://packs.example/pack-" + HASH + ".zip", HASH, true, null);
+
+        ResourcePackRequest request = definition.toRequest(true);
+
+        assertFalse(request.replace(), "replace(true) is implemented as pop-all-then-push and must never be used");
+        assertTrue(request.required());
+        assertEquals(1, request.packs().size());
+        assertEquals(ID, request.packs().getFirst().id());
+        assertEquals(HASH, request.packs().getFirst().hash());
+    }
+
+    @Test
+    @DisplayName("The required flag can be softened per push")
+    void testRequirementCanBeSoftened() {
+        ResourcePackDefinition definition = new ResourcePackDefinition(ID, "https://packs.example/pack-" + HASH + ".zip", HASH, true, null);
+
+        assertFalse(definition.toRequest(false).required());
+    }
+
+    @Test
+    @DisplayName("A configured prompt is parsed as MiniMessage, an absent one stays absent")
+    void testPrompt() {
+        ResourcePackDefinition withPrompt = new ResourcePackDefinition(ID, "https://packs.example/base.zip", HASH, false, "<red>Please accept");
+        ResourcePackDefinition withoutPrompt = new ResourcePackDefinition(ID, "https://packs.example/base.zip", HASH, false, "  ");
+
+        assertNotNull(withPrompt.promptComponent());
+        assertNull(withoutPrompt.promptComponent());
+    }
+}

--- a/common/src/test/java/net/onelitefeather/titan/common/resourcepack/ResourcePackSeasonWatcherTest.java
+++ b/common/src/test/java/net/onelitefeather/titan/common/resourcepack/ResourcePackSeasonWatcherTest.java
@@ -1,0 +1,196 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.common.resourcepack;
+
+import net.minestom.server.entity.Player;
+import net.minestom.server.instance.Instance;
+import net.minestom.server.network.packet.server.common.ResourcePackPopPacket;
+import net.minestom.server.network.packet.server.common.ResourcePackPushPacket;
+import net.minestom.testing.Collector;
+import net.minestom.testing.Env;
+import net.minestom.testing.TestConnection;
+import net.minestom.testing.extension.MicrotusExtension;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the trigger, not the swap. {@link ResourcePackService#applySeason} is exercised
+ * elsewhere; what these tests are about is that something in the running lobby actually reaches
+ * it when an operator edits {@code resource-packs.json}.
+ */
+@ExtendWith(MicrotusExtension.class)
+class ResourcePackSeasonWatcherTest {
+
+    private static final String BASE_HASH = "1111111111111111111111111111111111111111";
+    private static final String SEASON_HASH = "2222222222222222222222222222222222222222";
+    private static final String NEXT_SEASON_HASH = "3333333333333333333333333333333333333333";
+
+    private static final UUID BASE_ID = UUID.fromString("00000000-0000-4000-8000-00000000ba5e");
+    private static final UUID SEASON_ID = UUID.fromString("00000000-0000-4000-8000-000000005ea0");
+    private static final UUID NEXT_SEASON_ID = UUID.fromString("00000000-0000-4000-8000-000000005ea1");
+
+    private static final Duration POLL = Duration.ofMillis(20);
+    private static final Duration PATIENCE = Duration.ofSeconds(10);
+
+    /**
+     * Writes a configuration with the base pack and, optionally, a season pack.
+     *
+     * @param directory  the directory to write into
+     * @param seasonId   the season pack identifier, or {@code null} for no season
+     * @param seasonHash the season pack hash, ignored when there is no season
+     * @throws IOException when the file cannot be written
+     */
+    private static void writeConfiguration(Path directory, UUID seasonId, String seasonHash) throws IOException {
+        String season = seasonId == null ? "" : """
+                ,
+                  "season": {
+                    "id": "%s",
+                    "url": "https://packs.example/season-%s.zip",
+                    "hash": "%s"
+                  }""".formatted(seasonId, seasonHash, seasonHash);
+        Files.writeString(directory.resolve(ResourcePackSettingsProvider.FILE_NAME), """
+                {
+                  "base": {
+                    "id": "%s",
+                    "url": "https://packs.example/pack-%s.zip",
+                    "hash": "%s"
+                  }%s,
+                  "responseTimeoutMillis": -1
+                }
+                """.formatted(BASE_ID, BASE_HASH, BASE_HASH, season));
+    }
+
+    private static ResourcePackService service(Path directory) {
+        return new ResourcePackService(ResourcePackSettingsProvider.load(directory), new HeldPackRegistry(), BedrockDetector.never(), PackTimeoutScheduler.never());
+    }
+
+    @Test
+    @DisplayName("A season swapped in resource-packs.json reaches a player who is already online")
+    void testEditedSeasonReachesOnlinePlayers(Env env, @TempDir Path directory) throws IOException {
+        writeConfiguration(directory, SEASON_ID, SEASON_HASH);
+        ResourcePackService service = service(directory);
+        assertEquals(SEASON_ID, service.settings().season().id());
+
+        Instance instance = env.createFlatInstance();
+        TestConnection connection = env.createConnection();
+        Player player = connection.connect(instance);
+        service.onConfiguration(player);
+        assertTrue(service.registry().holds(player.getUuid(), PackSlot.SEASON, SEASON_ID));
+
+        Collector<ResourcePackPopPacket> pops = connection.trackIncoming(ResourcePackPopPacket.class);
+        Collector<ResourcePackPushPacket> pushes = connection.trackIncoming(ResourcePackPushPacket.class);
+
+        // The operator edits the file at midnight. Nobody calls anything else.
+        writeConfiguration(directory, NEXT_SEASON_ID, NEXT_SEASON_HASH);
+
+        // Nothing but the timer drives this. A collector cannot be used as the tick condition:
+        // Collector#collect() unregisters the tracker, so asking it would throw the packets away.
+        try (ResourcePackSeasonWatcher watcher = new ResourcePackSeasonWatcher(directory, service, () -> List.of(player), POLL, env.process().scheduler())) {
+            watcher.start();
+            assertTrue(env.tickWhile(() -> !service.registry().holds(player.getUuid(), PackSlot.SEASON, NEXT_SEASON_ID), PATIENCE), "The lobby never picked the new season up from the configuration file");
+        }
+
+        pops.assertSingle(packet -> assertEquals(SEASON_ID, packet.id(), "Only the season pack is removed"));
+        pushes.assertSingle(packet -> assertEquals(NEXT_SEASON_ID, packet.id()));
+        assertTrue(service.registry().holds(player.getUuid(), PackSlot.BASE, BASE_ID), "The base pack survives a season change");
+        assertEquals(NEXT_SEASON_ID, service.settings().season().id(), "The swap also applies to everyone who joins later");
+    }
+
+    @Test
+    @DisplayName("An unchanged configuration file swaps nothing, however often it is read")
+    void testUnchangedFileDoesNothing(Env env, @TempDir Path directory) throws IOException {
+        writeConfiguration(directory, SEASON_ID, SEASON_HASH);
+        ResourcePackService service = service(directory);
+
+        Instance instance = env.createFlatInstance();
+        TestConnection connection = env.createConnection();
+        Player player = connection.connect(instance);
+        service.onConfiguration(player);
+
+        Collector<ResourcePackPopPacket> pops = connection.trackIncoming(ResourcePackPopPacket.class);
+        Collector<ResourcePackPushPacket> pushes = connection.trackIncoming(ResourcePackPushPacket.class);
+
+        ResourcePackSeasonWatcher watcher = new ResourcePackSeasonWatcher(directory, service, () -> List.of(player), POLL, env.process().scheduler());
+        assertFalse(watcher.poll());
+        assertFalse(watcher.poll());
+
+        pops.assertEmpty();
+        pushes.assertEmpty();
+    }
+
+    @Test
+    @DisplayName("A season removed from the file ends the season without touching the base pack")
+    void testSeasonEndReachesOnlinePlayers(Env env, @TempDir Path directory) throws IOException {
+        writeConfiguration(directory, SEASON_ID, SEASON_HASH);
+        ResourcePackService service = service(directory);
+
+        Instance instance = env.createFlatInstance();
+        TestConnection connection = env.createConnection();
+        Player player = connection.connect(instance);
+        service.onConfiguration(player);
+
+        Collector<ResourcePackPopPacket> pops = connection.trackIncoming(ResourcePackPopPacket.class);
+        Collector<ResourcePackPushPacket> pushes = connection.trackIncoming(ResourcePackPushPacket.class);
+
+        writeConfiguration(directory, null, null);
+        ResourcePackSeasonWatcher watcher = new ResourcePackSeasonWatcher(directory, service, () -> List.of(player), POLL, env.process().scheduler());
+        assertTrue(watcher.poll());
+
+        pops.assertSingle(packet -> assertEquals(SEASON_ID, packet.id()));
+        pushes.assertEmpty();
+        assertTrue(service.registry().holds(player.getUuid(), PackSlot.BASE, BASE_ID));
+    }
+
+    @Test
+    @DisplayName("A half-written or deleted file does not strip the packs the players already hold")
+    void testUnreadableFileKeepsTheCurrentSeason(Env env, @TempDir Path directory) throws IOException {
+        writeConfiguration(directory, SEASON_ID, SEASON_HASH);
+        ResourcePackService service = service(directory);
+
+        Instance instance = env.createFlatInstance();
+        TestConnection connection = env.createConnection();
+        Player player = connection.connect(instance);
+        service.onConfiguration(player);
+
+        Collector<ResourcePackPopPacket> pops = connection.trackIncoming(ResourcePackPopPacket.class);
+        ResourcePackSeasonWatcher watcher = new ResourcePackSeasonWatcher(directory, service, () -> List.of(player), POLL, env.process().scheduler());
+
+        Files.writeString(directory.resolve(ResourcePackSettingsProvider.FILE_NAME), "{ \"base\": ");
+        assertFalse(watcher.poll(), "Broken json must not read as an ended season");
+
+        Files.delete(directory.resolve(ResourcePackSettingsProvider.FILE_NAME));
+        assertFalse(watcher.poll(), "A missing file must not read as an ended season");
+
+        pops.assertEmpty();
+        assertNotNull(service.settings().season());
+        assertTrue(service.registry().holds(player.getUuid(), PackSlot.SEASON, SEASON_ID));
+    }
+}

--- a/common/src/test/java/net/onelitefeather/titan/common/resourcepack/ResourcePackServiceIntegrationTest.java
+++ b/common/src/test/java/net/onelitefeather/titan/common/resourcepack/ResourcePackServiceIntegrationTest.java
@@ -1,0 +1,326 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.common.resourcepack;
+
+import net.kyori.adventure.resource.ResourcePackStatus;
+import net.minestom.server.entity.Player;
+import net.minestom.server.instance.Instance;
+import net.minestom.server.network.packet.server.common.ResourcePackPopPacket;
+import net.minestom.server.network.packet.server.common.ResourcePackPushPacket;
+import net.minestom.testing.Collector;
+import net.minestom.testing.Env;
+import net.minestom.testing.TestConnection;
+import net.minestom.testing.extension.MicrotusExtension;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MicrotusExtension.class)
+class ResourcePackServiceIntegrationTest {
+
+    private static final String BASE_HASH = "1111111111111111111111111111111111111111";
+    private static final String SEASON_HASH = "2222222222222222222222222222222222222222";
+    private static final String NEXT_SEASON_HASH = "3333333333333333333333333333333333333333";
+
+    private static final ResourcePackDefinition BASE = new ResourcePackDefinition(UUID.fromString("00000000-0000-4000-8000-00000000ba5e"), "https://packs.example/pack-" + BASE_HASH + ".zip", BASE_HASH, false, null);
+    private static final ResourcePackDefinition SEASON = new ResourcePackDefinition(UUID.fromString("00000000-0000-4000-8000-000000005ea0"), "https://packs.example/pack-" + SEASON_HASH + ".zip", SEASON_HASH, false, null);
+    private static final ResourcePackDefinition NEXT_SEASON = new ResourcePackDefinition(UUID.fromString("00000000-0000-4000-8000-000000005ea1"), "https://packs.example/pack-" + NEXT_SEASON_HASH + ".zip", NEXT_SEASON_HASH, false, null);
+
+    /** Collects the timeout guards instead of running them, so a test can fire them on demand. */
+    private static final class ManualScheduler implements PackTimeoutScheduler {
+
+        private final Deque<Runnable> pending = new ArrayDeque<>();
+
+        @Override
+        public void schedule(Runnable task, Duration delay) {
+            this.pending.add(task);
+        }
+
+        private void runAll() {
+            while (!this.pending.isEmpty()) {
+                this.pending.poll().run();
+            }
+        }
+    }
+
+    private static ResourcePackSettings settings(ResourcePackDefinition base, ResourcePackDefinition season) {
+        return new ResourcePackSettings(base, season, 5000L, false, ".");
+    }
+
+    private static ResourcePackService service(ResourcePackSettings settings, BedrockDetector detector, PackTimeoutScheduler scheduler) {
+        return new ResourcePackService(settings, new HeldPackRegistry(), detector, scheduler);
+    }
+
+    @Test
+    @DisplayName("An unconfigured lobby sends no resource pack packet at all")
+    void testUnconfiguredLobbySendsNothing(Env env) {
+        Instance instance = env.createFlatInstance();
+        TestConnection connection = env.createConnection();
+        Collector<ResourcePackPushPacket> pushes = connection.trackIncoming(ResourcePackPushPacket.class);
+        Collector<ResourcePackPopPacket> pops = connection.trackIncoming(ResourcePackPopPacket.class);
+        Player player = connection.connect(instance);
+
+        ResourcePackService service = service(ResourcePackSettings.disabled(), BedrockDetector.never(), PackTimeoutScheduler.immediate());
+        assertFalse(service.enabled());
+        service.onConfiguration(player);
+        service.applySeason(null, List.of(player));
+
+        pushes.assertEmpty();
+        pops.assertEmpty();
+    }
+
+    @Test
+    @DisplayName("Base and season pack are pushed as two packs, each with its own id and hash")
+    void testBaseAndSeasonArePushed(Env env) {
+        Instance instance = env.createFlatInstance();
+        TestConnection connection = env.createConnection();
+        Collector<ResourcePackPushPacket> pushes = connection.trackIncoming(ResourcePackPushPacket.class);
+        Collector<ResourcePackPopPacket> pops = connection.trackIncoming(ResourcePackPopPacket.class);
+        Player player = connection.connect(instance);
+
+        ResourcePackService service = service(settings(BASE, SEASON), BedrockDetector.never(), PackTimeoutScheduler.immediate());
+        service.onConfiguration(player);
+
+        List<ResourcePackPushPacket> pushed = pushes.collect();
+        assertEquals(2, pushed.size());
+        assertEquals(BASE.id(), pushed.get(0).id());
+        assertEquals(BASE_HASH, pushed.get(0).hash());
+        assertEquals(SEASON.id(), pushed.get(1).id());
+        assertEquals(SEASON_HASH, pushed.get(1).hash());
+        pops.assertEmpty();
+    }
+
+    @Test
+    @DisplayName("A pack the player already holds is not pushed a second time")
+    void testHeldPackIsNotPushedAgain(Env env) {
+        Instance instance = env.createFlatInstance();
+        TestConnection connection = env.createConnection();
+        Collector<ResourcePackPushPacket> pushes = connection.trackIncoming(ResourcePackPushPacket.class);
+        Player player = connection.connect(instance);
+
+        ResourcePackService service = service(settings(BASE, SEASON), BedrockDetector.never(), PackTimeoutScheduler.immediate());
+        service.onConfiguration(player);
+        service.onConfiguration(player);
+
+        assertEquals(2, pushes.collect().size());
+    }
+
+    @Test
+    @DisplayName("A season change pops only the season id and pushes the new one, the base pack stays")
+    void testSeasonChangeSwapsOnlyTheSeason(Env env) {
+        Instance instance = env.createFlatInstance();
+        TestConnection connection = env.createConnection();
+        Player player = connection.connect(instance);
+
+        ResourcePackService service = service(settings(BASE, SEASON), BedrockDetector.never(), PackTimeoutScheduler.immediate());
+        service.onConfiguration(player);
+
+        Collector<ResourcePackPushPacket> pushes = connection.trackIncoming(ResourcePackPushPacket.class);
+        Collector<ResourcePackPopPacket> pops = connection.trackIncoming(ResourcePackPopPacket.class);
+        service.applySeason(NEXT_SEASON, List.of(player));
+
+        List<ResourcePackPopPacket> popped = pops.collect();
+        assertEquals(1, popped.size(), "Exactly one pack is removed on a season change");
+        assertEquals(SEASON.id(), popped.getFirst().id());
+        assertNotNull(popped.getFirst().id(), "A pop without an id clears every pack the client holds");
+
+        List<ResourcePackPushPacket> pushed = pushes.collect();
+        assertEquals(1, pushed.size(), "Only the new season is pushed, the base pack is not resent");
+        assertEquals(NEXT_SEASON.id(), pushed.getFirst().id());
+
+        assertTrue(service.registry().holds(player.getUuid(), PackSlot.BASE, BASE.id()));
+        assertTrue(service.registry().holds(player.getUuid(), PackSlot.SEASON, NEXT_SEASON.id()));
+    }
+
+    @Test
+    @DisplayName("Ending a season pops it without pushing a successor")
+    void testSeasonEnd(Env env) {
+        Instance instance = env.createFlatInstance();
+        TestConnection connection = env.createConnection();
+        Player player = connection.connect(instance);
+
+        ResourcePackService service = service(settings(BASE, SEASON), BedrockDetector.never(), PackTimeoutScheduler.immediate());
+        service.onConfiguration(player);
+
+        Collector<ResourcePackPushPacket> pushes = connection.trackIncoming(ResourcePackPushPacket.class);
+        Collector<ResourcePackPopPacket> pops = connection.trackIncoming(ResourcePackPopPacket.class);
+        service.applySeason(null, List.of(player));
+
+        pops.assertSingle(packet -> assertEquals(SEASON.id(), packet.id()));
+        pushes.assertEmpty();
+        assertTrue(service.registry().entry(player.getUuid(), PackSlot.SEASON).isEmpty());
+        assertTrue(service.registry().holds(player.getUuid(), PackSlot.BASE, BASE.id()));
+    }
+
+    @Test
+    @DisplayName("A season change reaches players who join afterwards")
+    void testSeasonChangeAppliesToLaterJoins(Env env) {
+        Instance instance = env.createFlatInstance();
+        ResourcePackService service = service(settings(BASE, SEASON), BedrockDetector.never(), PackTimeoutScheduler.immediate());
+        service.applySeason(NEXT_SEASON, List.of());
+
+        TestConnection connection = env.createConnection();
+        Collector<ResourcePackPushPacket> pushes = connection.trackIncoming(ResourcePackPushPacket.class);
+        Player player = connection.connect(instance);
+        service.onConfiguration(player);
+
+        List<ResourcePackPushPacket> pushed = pushes.collect();
+        assertEquals(2, pushed.size());
+        assertEquals(NEXT_SEASON.id(), pushed.get(1).id());
+    }
+
+    @Test
+    @DisplayName("A bedrock player receives nothing, because geyser would confirm a pack it never delivered")
+    void testBedrockPlayerReceivesNothing(Env env) {
+        Instance instance = env.createFlatInstance();
+        TestConnection connection = env.createConnection();
+        Collector<ResourcePackPushPacket> pushes = connection.trackIncoming(ResourcePackPushPacket.class);
+        Collector<ResourcePackPopPacket> pops = connection.trackIncoming(ResourcePackPopPacket.class);
+        Player player = connection.connect(instance);
+
+        ResourcePackService service = service(settings(BASE, SEASON), (id, name) -> true, PackTimeoutScheduler.immediate());
+        service.onConfiguration(player);
+        service.applySeason(NEXT_SEASON, List.of(player));
+
+        pushes.assertEmpty();
+        pops.assertEmpty();
+        assertEquals(0, service.registry().trackedPlayers());
+    }
+
+    @Test
+    @DisplayName("A bedrock player's reported success is ignored instead of being believed")
+    void testBedrockStatusIsIgnored(Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+
+        ResourcePackSettings settings = new ResourcePackSettings(BASE, null, 5000L, true, ".");
+        ResourcePackService service = service(settings, (id, name) -> true, PackTimeoutScheduler.immediate());
+        service.onConfiguration(player);
+
+        service.onStatus(player, BASE.id(), ResourcePackStatus.SUCCESSFULLY_LOADED);
+
+        assertFalse(service.registry().entry(player.getUuid(), PackSlot.BASE).orElseThrow().confirmed(), "Geyser reports success without delivering, so the book must not record it as loaded");
+    }
+
+    @Test
+    @DisplayName("A java player's answer updates the book")
+    void testStatusUpdatesTheBook(Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+
+        ResourcePackService service = service(settings(BASE, SEASON), BedrockDetector.never(), PackTimeoutScheduler.immediate());
+        service.onConfiguration(player);
+
+        service.onStatus(player, BASE.id(), ResourcePackStatus.DOWNLOADED);
+        assertFalse(service.registry().entry(player.getUuid(), PackSlot.BASE).orElseThrow().confirmed(), "An intermediate status decides nothing");
+
+        service.onStatus(player, BASE.id(), ResourcePackStatus.SUCCESSFULLY_LOADED);
+        assertTrue(service.registry().entry(player.getUuid(), PackSlot.BASE).orElseThrow().confirmed());
+
+        service.onStatus(player, SEASON.id(), ResourcePackStatus.DECLINED);
+        assertTrue(service.registry().entry(player.getUuid(), PackSlot.SEASON).isEmpty(), "A declined pack is not held");
+    }
+
+    @Test
+    @DisplayName("A declined pack is offered again on the next configuration")
+    void testDeclinedPackIsPushedAgain(Env env) {
+        Instance instance = env.createFlatInstance();
+        TestConnection connection = env.createConnection();
+        Collector<ResourcePackPushPacket> pushes = connection.trackIncoming(ResourcePackPushPacket.class);
+        Player player = connection.connect(instance);
+
+        ResourcePackService service = service(settings(BASE, null), BedrockDetector.never(), PackTimeoutScheduler.immediate());
+        service.onConfiguration(player);
+        service.onStatus(player, BASE.id(), ResourcePackStatus.DECLINED);
+        service.onConfiguration(player);
+
+        assertEquals(2, pushes.collect().size());
+    }
+
+    @Test
+    @DisplayName("A disconnect clears the book")
+    void testDisconnectClearsTheBook(Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+
+        ResourcePackService service = service(settings(BASE, SEASON), BedrockDetector.never(), PackTimeoutScheduler.immediate());
+        service.onConfiguration(player);
+        assertEquals(1, service.registry().trackedPlayers());
+
+        service.onDisconnect(player.getUuid());
+
+        assertEquals(0, service.registry().trackedPlayers());
+    }
+
+    @Test
+    @DisplayName("The timeout guard completes the pack future a parked configuration thread waits on")
+    void testTimeoutCompletesThePendingFuture(Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+
+        ManualScheduler scheduler = new ManualScheduler();
+        ResourcePackService service = service(settings(BASE, null), BedrockDetector.never(), scheduler);
+        service.onConfiguration(player);
+
+        CompletableFuture<Void> future = player.getResourcePackFuture();
+        assertNotNull(future, "A pushed pack leaves a future that doConfiguration joins without a timeout");
+        assertFalse(future.isDone(), "Nothing else completes that future while the client stays silent");
+        assertEquals(1, scheduler.pending.size(), "Every push arms exactly one guard");
+
+        scheduler.runAll();
+
+        assertTrue(future.isDone(), "The guard has to release the configuration thread itself");
+    }
+
+    @Test
+    @DisplayName("No pack pushed means no guard armed")
+    void testNoGuardWithoutPush(Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+
+        ManualScheduler scheduler = new ManualScheduler();
+        ResourcePackService service = service(ResourcePackSettings.disabled(), BedrockDetector.never(), scheduler);
+        service.onConfiguration(player);
+
+        assertTrue(scheduler.pending.isEmpty());
+    }
+
+    @Test
+    @DisplayName("A negative timeout leaves the guard off")
+    void testTimeoutCanBeDisabled(Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+
+        ManualScheduler scheduler = new ManualScheduler();
+        ResourcePackService service = new ResourcePackService(new ResourcePackSettings(BASE, null, -1L, false, "."), new HeldPackRegistry(), BedrockDetector.never(), scheduler);
+        service.onConfiguration(player);
+
+        assertTrue(scheduler.pending.isEmpty());
+    }
+}

--- a/common/src/test/java/net/onelitefeather/titan/common/resourcepack/ResourcePackServiceIntegrationTest.java
+++ b/common/src/test/java/net/onelitefeather/titan/common/resourcepack/ResourcePackServiceIntegrationTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Duration;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import java.util.UUID;
@@ -39,6 +40,8 @@ import java.util.concurrent.CompletableFuture;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MicrotusExtension.class)
@@ -86,7 +89,7 @@ class ResourcePackServiceIntegrationTest {
         Collector<ResourcePackPopPacket> pops = connection.trackIncoming(ResourcePackPopPacket.class);
         Player player = connection.connect(instance);
 
-        ResourcePackService service = service(ResourcePackSettings.disabled(), BedrockDetector.never(), PackTimeoutScheduler.immediate());
+        ResourcePackService service = service(ResourcePackSettings.disabled(), BedrockDetector.never(), PackTimeoutScheduler.never());
         assertFalse(service.enabled());
         service.onConfiguration(player);
         service.applySeason(null, List.of(player));
@@ -104,7 +107,7 @@ class ResourcePackServiceIntegrationTest {
         Collector<ResourcePackPopPacket> pops = connection.trackIncoming(ResourcePackPopPacket.class);
         Player player = connection.connect(instance);
 
-        ResourcePackService service = service(settings(BASE, SEASON), BedrockDetector.never(), PackTimeoutScheduler.immediate());
+        ResourcePackService service = service(settings(BASE, SEASON), BedrockDetector.never(), PackTimeoutScheduler.never());
         service.onConfiguration(player);
 
         List<ResourcePackPushPacket> pushed = pushes.collect();
@@ -124,7 +127,7 @@ class ResourcePackServiceIntegrationTest {
         Collector<ResourcePackPushPacket> pushes = connection.trackIncoming(ResourcePackPushPacket.class);
         Player player = connection.connect(instance);
 
-        ResourcePackService service = service(settings(BASE, SEASON), BedrockDetector.never(), PackTimeoutScheduler.immediate());
+        ResourcePackService service = service(settings(BASE, SEASON), BedrockDetector.never(), PackTimeoutScheduler.never());
         service.onConfiguration(player);
         service.onConfiguration(player);
 
@@ -138,7 +141,7 @@ class ResourcePackServiceIntegrationTest {
         TestConnection connection = env.createConnection();
         Player player = connection.connect(instance);
 
-        ResourcePackService service = service(settings(BASE, SEASON), BedrockDetector.never(), PackTimeoutScheduler.immediate());
+        ResourcePackService service = service(settings(BASE, SEASON), BedrockDetector.never(), PackTimeoutScheduler.never());
         service.onConfiguration(player);
 
         Collector<ResourcePackPushPacket> pushes = connection.trackIncoming(ResourcePackPushPacket.class);
@@ -165,7 +168,7 @@ class ResourcePackServiceIntegrationTest {
         TestConnection connection = env.createConnection();
         Player player = connection.connect(instance);
 
-        ResourcePackService service = service(settings(BASE, SEASON), BedrockDetector.never(), PackTimeoutScheduler.immediate());
+        ResourcePackService service = service(settings(BASE, SEASON), BedrockDetector.never(), PackTimeoutScheduler.never());
         service.onConfiguration(player);
 
         Collector<ResourcePackPushPacket> pushes = connection.trackIncoming(ResourcePackPushPacket.class);
@@ -182,7 +185,7 @@ class ResourcePackServiceIntegrationTest {
     @DisplayName("A season change reaches players who join afterwards")
     void testSeasonChangeAppliesToLaterJoins(Env env) {
         Instance instance = env.createFlatInstance();
-        ResourcePackService service = service(settings(BASE, SEASON), BedrockDetector.never(), PackTimeoutScheduler.immediate());
+        ResourcePackService service = service(settings(BASE, SEASON), BedrockDetector.never(), PackTimeoutScheduler.never());
         service.applySeason(NEXT_SEASON, List.of());
 
         TestConnection connection = env.createConnection();
@@ -204,7 +207,7 @@ class ResourcePackServiceIntegrationTest {
         Collector<ResourcePackPopPacket> pops = connection.trackIncoming(ResourcePackPopPacket.class);
         Player player = connection.connect(instance);
 
-        ResourcePackService service = service(settings(BASE, SEASON), (id, name) -> true, PackTimeoutScheduler.immediate());
+        ResourcePackService service = service(settings(BASE, SEASON), (id, name) -> true, PackTimeoutScheduler.never());
         service.onConfiguration(player);
         service.applySeason(NEXT_SEASON, List.of(player));
 
@@ -220,7 +223,7 @@ class ResourcePackServiceIntegrationTest {
         Player player = env.createPlayer(instance);
 
         ResourcePackSettings settings = new ResourcePackSettings(BASE, null, 5000L, true, ".");
-        ResourcePackService service = service(settings, (id, name) -> true, PackTimeoutScheduler.immediate());
+        ResourcePackService service = service(settings, (id, name) -> true, PackTimeoutScheduler.never());
         service.onConfiguration(player);
 
         service.onStatus(player, BASE.id(), ResourcePackStatus.SUCCESSFULLY_LOADED);
@@ -234,7 +237,7 @@ class ResourcePackServiceIntegrationTest {
         Instance instance = env.createFlatInstance();
         Player player = env.createPlayer(instance);
 
-        ResourcePackService service = service(settings(BASE, SEASON), BedrockDetector.never(), PackTimeoutScheduler.immediate());
+        ResourcePackService service = service(settings(BASE, SEASON), BedrockDetector.never(), PackTimeoutScheduler.never());
         service.onConfiguration(player);
 
         service.onStatus(player, BASE.id(), ResourcePackStatus.DOWNLOADED);
@@ -255,7 +258,7 @@ class ResourcePackServiceIntegrationTest {
         Collector<ResourcePackPushPacket> pushes = connection.trackIncoming(ResourcePackPushPacket.class);
         Player player = connection.connect(instance);
 
-        ResourcePackService service = service(settings(BASE, null), BedrockDetector.never(), PackTimeoutScheduler.immediate());
+        ResourcePackService service = service(settings(BASE, null), BedrockDetector.never(), PackTimeoutScheduler.never());
         service.onConfiguration(player);
         service.onStatus(player, BASE.id(), ResourcePackStatus.DECLINED);
         service.onConfiguration(player);
@@ -269,7 +272,7 @@ class ResourcePackServiceIntegrationTest {
         Instance instance = env.createFlatInstance();
         Player player = env.createPlayer(instance);
 
-        ResourcePackService service = service(settings(BASE, SEASON), BedrockDetector.never(), PackTimeoutScheduler.immediate());
+        ResourcePackService service = service(settings(BASE, SEASON), BedrockDetector.never(), PackTimeoutScheduler.never());
         service.onConfiguration(player);
         assertEquals(1, service.registry().trackedPlayers());
 
@@ -309,6 +312,111 @@ class ResourcePackServiceIntegrationTest {
         service.onConfiguration(player);
 
         assertTrue(scheduler.pending.isEmpty());
+    }
+
+    @Test
+    @DisplayName("An expired guard leaves no stale future behind, so the next request is waited on again")
+    void testExpiredGuardDoesNotPoisonTheNextRequest(Env env) {
+        // Scenario A: the client never answers. Minestom clears Player#resourcePackFuture only
+        // inside onResourcePackStatus, so a guard that merely completes the future from outside
+        // leaves it in the field, completed, forever - and sendResourcePacks then reuses it
+        // instead of creating a new one. Every later configuration pass would join an
+        // already-completed future and stop waiting for packs at all.
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+
+        ManualScheduler scheduler = new ManualScheduler();
+        ResourcePackService service = service(settings(BASE, SEASON), BedrockDetector.never(), scheduler);
+        service.onConfiguration(player);
+        CompletableFuture<Void> first = player.getResourcePackFuture();
+        assertNotNull(first);
+
+        scheduler.runAll();
+
+        assertTrue(first.isDone(), "The parked configuration thread has to be released");
+        assertNull(player.getResourcePackFuture(), "The expired request must not stay in the player's future field");
+        assertTrue(service.registry().entry(player.getUuid(), PackSlot.BASE).isEmpty(), "A pack that timed out is not held");
+        assertTrue(service.registry().entry(player.getUuid(), PackSlot.SEASON).isEmpty(), "A pack that timed out is not held");
+
+        service.applySeason(NEXT_SEASON, List.of(player));
+
+        CompletableFuture<Void> second = player.getResourcePackFuture();
+        assertNotNull(second, "The next push has to create a future of its own");
+        assertNotSame(first, second);
+        assertFalse(second.isDone(), "The next configuration pass has to wait for the client again");
+    }
+
+    @Test
+    @DisplayName("A guard belonging to an answered request never releases the request that follows it")
+    void testStaleGuardDoesNotReleaseALaterRequest(Env env) {
+        // Scenario B: the client answers in time, but the guard armed for that request is still
+        // queued. A guard that looks the future up when it fires would find the *next* request's
+        // future and complete it - letting configuration proceed before the client answered.
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+
+        ManualScheduler scheduler = new ManualScheduler();
+        ResourcePackService service = service(settings(BASE, null), BedrockDetector.never(), scheduler);
+        service.onConfiguration(player);
+        CompletableFuture<Void> first = player.getResourcePackFuture();
+        assertNotNull(first);
+        assertEquals(1, scheduler.pending.size());
+
+        // The client answers the first request. Minestom completes and clears the future.
+        player.onResourcePackStatus(BASE.id(), ResourcePackStatus.SUCCESSFULLY_LOADED);
+        service.onStatus(player, BASE.id(), ResourcePackStatus.SUCCESSFULLY_LOADED);
+        assertTrue(first.isDone());
+        assertNull(player.getResourcePackFuture());
+
+        // A second request goes out while the first guard is still queued.
+        service.applySeason(SEASON, List.of(player));
+        CompletableFuture<Void> second = player.getResourcePackFuture();
+        assertNotNull(second);
+        assertNotSame(first, second);
+
+        // The stale guard fires. It belongs to the answered request and must do nothing.
+        scheduler.pending.poll().run();
+
+        assertFalse(second.isDone(), "The stale guard released a request the client has not answered yet");
+        assertTrue(service.registry().holds(player.getUuid(), PackSlot.SEASON, SEASON.id()), "The stale guard must not touch the pack of a later request");
+        assertTrue(service.registry().holds(player.getUuid(), PackSlot.BASE, BASE.id()), "The confirmed base pack must survive a stale guard");
+    }
+
+    @Test
+    @DisplayName("A guard is only armed for the request that actually pushed something")
+    void testGuardIsArmedPerRequest(Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+
+        ManualScheduler scheduler = new ManualScheduler();
+        ResourcePackService service = service(settings(BASE, SEASON), BedrockDetector.never(), scheduler);
+        service.onConfiguration(player);
+        assertEquals(1, scheduler.pending.size());
+
+        // Nothing new to push - the player already holds both packs.
+        service.onConfiguration(player);
+        assertEquals(1, scheduler.pending.size(), "A request that pushes nothing must not arm a guard");
+    }
+
+    @Test
+    @DisplayName("A terminal status is routed to the condition of its own slot")
+    void testConditionIsCalledForItsSlot(Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+
+        List<ResourcePackStatus> base = new ArrayList<>();
+        List<ResourcePackStatus> season = new ArrayList<>();
+        ResourcePackService service = service(settings(BASE, SEASON), BedrockDetector.never(), PackTimeoutScheduler.never()).withCondition(PackSlot.BASE, (reporter, status) -> base.add(status)).withCondition(PackSlot.SEASON, (reporter, status) -> season.add(status));
+        service.onConfiguration(player);
+
+        service.onStatus(player, BASE.id(), ResourcePackStatus.DOWNLOADED);
+        assertEquals(List.of(), base, "An intermediate status is not a verdict");
+
+        service.onStatus(player, BASE.id(), ResourcePackStatus.FAILED_DOWNLOAD);
+        service.onStatus(player, SEASON.id(), ResourcePackStatus.SUCCESSFULLY_LOADED);
+
+        assertEquals(List.of(ResourcePackStatus.FAILED_DOWNLOAD), base);
+        assertEquals(List.of(ResourcePackStatus.SUCCESSFULLY_LOADED), season);
     }
 
     @Test

--- a/common/src/test/java/net/onelitefeather/titan/common/resourcepack/ResourcePackSettingsProviderTest.java
+++ b/common/src/test/java/net/onelitefeather/titan/common/resourcepack/ResourcePackSettingsProviderTest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.common.resourcepack;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ResourcePackSettingsProviderTest {
+
+    private static final String HASH = "0123456789abcdef0123456789abcdef01234567";
+
+    @Test
+    @DisplayName("Without a configuration file the feature stays disabled and nothing is written")
+    void testMissingFile(@TempDir Path directory) throws IOException {
+        ResourcePackSettings settings = ResourcePackSettingsProvider.load(directory);
+
+        assertFalse(settings.enabled());
+        try (var entries = Files.list(directory)) {
+            assertEquals(List.of(), entries.toList(), "An unconfigured lobby must not create files of its own");
+        }
+    }
+
+    @Test
+    @DisplayName("A configured base and season pack are read with their identifiers and hashes")
+    void testConfiguredPacks(@TempDir Path directory) throws IOException {
+        UUID base = UUID.randomUUID();
+        UUID season = UUID.randomUUID();
+        Files.writeString(directory.resolve(ResourcePackSettingsProvider.FILE_NAME), """
+                {
+                  "base": {
+                    "id": "%s",
+                    "url": "https://packs.example/pack-%s.zip",
+                    "hash": "%s",
+                    "required": true
+                  },
+                  "season": {
+                    "id": "%s",
+                    "url": "https://packs.example/season-halloween-2026-%s.zip",
+                    "hash": "%s",
+                    "required": false,
+                    "prompt": "<gold>Halloween"
+                  },
+                  "responseTimeoutMillis": 4000,
+                  "sendToBedrockPlayers": false,
+                  "bedrockNamePrefix": "."
+                }
+                """.formatted(base, HASH, HASH, season, HASH, HASH));
+
+        ResourcePackSettings settings = ResourcePackSettingsProvider.load(directory);
+
+        assertTrue(settings.enabled());
+        assertEquals(base, settings.packFor(PackSlot.BASE).id());
+        assertTrue(settings.packFor(PackSlot.BASE).required());
+        assertEquals(season, settings.packFor(PackSlot.SEASON).id());
+        assertFalse(settings.packFor(PackSlot.SEASON).required());
+        assertEquals(4000L, settings.responseTimeoutMillis());
+        assertFalse(settings.sendToBedrockPlayers());
+    }
+
+    @Test
+    @DisplayName("A file without packs stays disabled")
+    void testEmptyConfiguration(@TempDir Path directory) throws IOException {
+        Files.writeString(directory.resolve(ResourcePackSettingsProvider.FILE_NAME), "{}");
+
+        ResourcePackSettings settings = ResourcePackSettingsProvider.load(directory);
+
+        assertFalse(settings.enabled());
+        assertEquals(ResourcePackSettings.DEFAULT_RESPONSE_TIMEOUT, settings.responseTimeout());
+    }
+
+    @Test
+    @DisplayName("A pack with a broken hash disables the feature instead of keeping players out")
+    void testInvalidPackIsRejected(@TempDir Path directory) throws IOException {
+        Files.writeString(directory.resolve(ResourcePackSettingsProvider.FILE_NAME), """
+                {
+                  "base": {
+                    "id": "%s",
+                    "url": "https://packs.example/base.zip",
+                    "hash": "nope"
+                  }
+                }
+                """.formatted(UUID.randomUUID()));
+
+        ResourcePackSettings settings = ResourcePackSettingsProvider.load(directory);
+
+        assertFalse(settings.enabled());
+        assertNull(settings.packFor(PackSlot.BASE));
+    }
+
+    @Test
+    @DisplayName("Malformed json disables the feature instead of keeping players out")
+    void testMalformedJson(@TempDir Path directory) throws IOException {
+        Files.writeString(directory.resolve(ResourcePackSettingsProvider.FILE_NAME), "{ this is not json");
+
+        assertFalse(ResourcePackSettingsProvider.load(directory).enabled());
+    }
+}

--- a/common/src/test/java/net/onelitefeather/titan/common/resourcepack/ResourcePackSettingsTest.java
+++ b/common/src/test/java/net/onelitefeather/titan/common/resourcepack/ResourcePackSettingsTest.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (C) 2025 OneLiteFeather Network
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.onelitefeather.titan.common.resourcepack;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ResourcePackSettingsTest {
+
+    private static final String HASH = "0123456789abcdef0123456789abcdef01234567";
+
+    private static ResourcePackDefinition pack() {
+        return new ResourcePackDefinition(UUID.randomUUID(), "https://packs.example/pack-" + HASH + ".zip", HASH, false, null);
+    }
+
+    @Test
+    @DisplayName("Without any pack the settings are disabled")
+    void testDisabled() {
+        ResourcePackSettings settings = ResourcePackSettings.disabled();
+
+        assertFalse(settings.enabled());
+        assertNull(settings.packFor(PackSlot.BASE));
+        assertNull(settings.packFor(PackSlot.SEASON));
+    }
+
+    @Test
+    @DisplayName("A season pack alone is enough to enable delivery")
+    void testSeasonOnlyIsEnabled() {
+        ResourcePackSettings settings = new ResourcePackSettings(null, pack(), 0L, false, ".");
+
+        assertTrue(settings.enabled());
+    }
+
+    @Test
+    @DisplayName("An unset timeout falls back to the default instead of meaning no timeout")
+    void testTimeoutDefault() {
+        ResourcePackSettings settings = new ResourcePackSettings(pack(), null, 0L, false, ".");
+
+        assertEquals(ResourcePackSettings.DEFAULT_RESPONSE_TIMEOUT, settings.responseTimeout());
+    }
+
+    @Test
+    @DisplayName("A negative timeout disables the guard, a positive one is kept")
+    void testTimeoutValues() {
+        assertTrue(new ResourcePackSettings(pack(), null, -1L, false, ".").responseTimeout().isNegative());
+        assertEquals(Duration.ofSeconds(3), new ResourcePackSettings(pack(), null, 3000L, false, ".").responseTimeout());
+    }
+
+    @Test
+    @DisplayName("Bedrock delivery is off unless the configuration turns it on")
+    void testBedrockDeliveryDefault() {
+        assertFalse(ResourcePackSettings.disabled().sendToBedrockPlayers());
+    }
+
+    @Test
+    @DisplayName("A missing bedrock prefix falls back to floodgate's default")
+    void testBedrockPrefixDefault() {
+        ResourcePackSettings settings = new ResourcePackSettings(pack(), null, 0L, false, null);
+
+        assertEquals(ResourcePackSettings.DEFAULT_BEDROCK_NAME_PREFIX, settings.bedrockNamePrefix());
+    }
+
+    @Test
+    @DisplayName("Changing the season leaves the base pack and every other value untouched")
+    void testWithSeason() {
+        ResourcePackDefinition base = pack();
+        ResourcePackDefinition oldSeason = pack();
+        ResourcePackDefinition newSeason = pack();
+        ResourcePackSettings settings = new ResourcePackSettings(base, oldSeason, 4000L, true, "!");
+
+        ResourcePackSettings changed = settings.withSeason(newSeason);
+
+        assertSame(base, changed.base());
+        assertSame(newSeason, changed.season());
+        assertEquals(4000L, changed.responseTimeoutMillis());
+        assertTrue(changed.sendToBedrockPlayers());
+        assertEquals("!", changed.bedrockNamePrefix());
+    }
+
+    @Test
+    @DisplayName("A season can end without a successor")
+    void testSeasonCanBeCleared() {
+        ResourcePackSettings settings = new ResourcePackSettings(pack(), pack(), 0L, false, ".");
+
+        ResourcePackSettings changed = settings.withSeason(null);
+
+        assertNull(changed.season());
+        assertTrue(changed.enabled());
+    }
+}

--- a/docs/rollout-log.md
+++ b/docs/rollout-log.md
@@ -26,11 +26,27 @@ ein Paket an den Client geht oder nicht. Für den Nachweis nach NFR-011 zählt
 derselbe Eintrag wie bei einem Flag: Datum, Übergang, Grund, verantwortliche
 Person.
 
+**Und nicht jedes Flag hat eine Stufe.** `RESOURCE_PACK_REQUIRED_KICK` (Stufe 6,
+US-6.05) ist ein reiner Notausschalter: er entscheidet, ob die Lobby einen Spieler
+trennt, der ein als `required` konfiguriertes Paket nicht lädt — sei es, weil er
+ablehnt, sei es, weil er gar nicht antwortet und die Timeout-Wache
+stellvertretend antwortet. Gelesen wird nur der An/Aus-Zustand. Eine Stufe hätte
+zur Folge, dass derselbe stumme Client je nach Gruppe getrennt oder eingelassen
+wird, und das Team wäre die unbrauchbarste Stichprobe für die eigentliche Frage,
+nämlich ob normale Clients das Paket rechtzeitig laden. In der Ausgabe von
+`/season status` erscheint das Flag trotzdem mit den Spalten Stufe und
+Zeitfenster — **bei diesem Flag sind beide bedeutungslos**, nur „an" oder „aus"
+zählt. Die Voreinstellung ist **an** (`@EnabledByDefault`): ohne
+`flags.properties`, oder wenn die Datei nicht lesbar ist, bleibt es beim
+bisherigen Verhalten und beim Versprechen, das `"required": true` gibt. Für
+diesen Schalter gilt derselbe Nachweis wie für jede Stufe: eine Zeile im Verlauf.
+
 ## Verlauf
 
 | Datum | Feature | von → nach | Grund | Verantwortlich |
 |---|---|---|---|---|
 | 2026-08-28 | Resource Packs (Stufe 6) | — → `aus` | Auslieferung, Saisonwechsel, Timeout-Wache und Bedrock-Erkennung sind implementiert und getestet (`:common` und `:app`). Auf keiner Lobby liegt eine `resource-packs.json`, das Feature ist damit überall abgeschaltet und hat noch keinen Spieler erreicht. | @TheMeinerLP |
+| 2026-08-29 | `RESOURCE_PACK_REQUIRED_KICK` (Stufe 6) | — → `an` | Neuer Notausschalter für das Trennen wegen eines Pflichtpakets, siehe US-6.05. Er startet an, weil das genau dem Verhalten entspricht, das bereits im Code stand: ein Flag einzuführen darf für sich genommen nichts ändern. Erreicht bisher ohnehin keinen Spieler, da nirgends eine `resource-packs.json` liegt. | @TheMeinerLP |
 
 ## Wie ein Eintrag entsteht
 

--- a/docs/rollout-log.md
+++ b/docs/rollout-log.md
@@ -18,11 +18,19 @@ Zeilen bleiben stehen — der Verlauf ist der Zweck.
 Der Notausschalter schlägt jede Stufe und jedes Zeitfenster. Die Prüfreihenfolge
 ist in US-3.07 festgelegt: erst Notausschalter, dann Stufe, dann Zeitfenster.
 
+**Nicht jedes Feature hängt an einem Togglz-Flag.** Die Resource-Pack-Auslieferung
+(Stufe 6) wird über die Datei `resource-packs.json` neben dem Server geschaltet:
+ohne Datei ist sie `aus` und registriert nicht einmal ihre Listener, mit Datei ist
+sie `ga` — eine Zwischenstufe für einzelne Spielergruppen gibt es dort nicht, weil
+ein Paket an den Client geht oder nicht. Für den Nachweis nach NFR-011 zählt
+derselbe Eintrag wie bei einem Flag: Datum, Übergang, Grund, verantwortliche
+Person.
+
 ## Verlauf
 
 | Datum | Feature | von → nach | Grund | Verantwortlich |
 |---|---|---|---|---|
-| — | — | — | noch kein Eintrag | — |
+| 2026-08-28 | Resource Packs (Stufe 6) | — → `aus` | Auslieferung, Saisonwechsel, Timeout-Wache und Bedrock-Erkennung sind implementiert und getestet (`:common` und `:app`). Auf keiner Lobby liegt eine `resource-packs.json`, das Feature ist damit überall abgeschaltet und hat noch keinen Spieler erreicht. | @TheMeinerLP |
 
 ## Wie ein Eintrag entsteht
 

--- a/docs/spec-lobby-saison-events.md
+++ b/docs/spec-lobby-saison-events.md
@@ -218,6 +218,7 @@ Rollout-Stand daher überall `aus`, siehe [`rollout-log.md`](rollout-log.md).
 | US-6.02 | Als Betreiber möchte ich beim Saisonwechsel nur das Saison-Paket tauschen. | When die Saison wechselt, shall die Lobby ausschließlich das Saison-Paket entfernen und ersetzen, nicht alle Pakete. | `resource_pack_pop(uuid)` | Could | umgesetzt |
 | US-6.03 | Als Betreiber möchte ich, dass ein hängender Client den Verbindungsaufbau nicht blockiert. | If ein Client nicht innerhalb einer konfigurierten Frist auf die Paketanfrage antwortet, then shall die Lobby fortfahren statt zu warten. | eigener Timeout | Could | umgesetzt |
 | US-6.04 | Als Betreiber möchte ich Bedrock-Spieler korrekt behandeln, weil deren gemeldeter Status nicht zutrifft. | If ein Spieler über Geyser verbunden ist, then shall die Lobby ihn nicht anhand des gemeldeten Paketstatus bewerten. | Bedrock-Erkennung | Could | umgesetzt |
+| US-6.05 | Als Betreiber möchte ich das Trennen wegen eines Pflichtpakets abschalten können, ohne die Paketauslieferung anzufassen. | Where das Flag `RESOURCE_PACK_REQUIRED_KICK` inaktiv ist, shall die Lobby ein als `required` konfiguriertes Paket als optional ausliefern und keinen Spieler wegen dieses Pakets trennen. | `TitanFeatures`, `flags.properties` | Could | umgesetzt |
 
 **Auslöser für US-6.02:** `ResourcePackSeasonWatcher` liest `resource-packs.json`
 alle fünf Sekunden neu und ruft bei geändertem Saison-Eintrag
@@ -236,6 +237,32 @@ Spielerobjekt stehen und jede spätere Konfigurationsphase wartet dann auf gar
 kein Paket mehr. Für ein als `required` konfiguriertes Paket bedeutet die
 stellvertretende Antwort einen Kick — dieselbe Regel, die Minestom auf jede
 andere endgültige Antwort anwendet.
+
+**Zum Notausschalter (US-6.05):** Ob ein Pflichtpaket überhaupt erzwungen wird,
+hängt am Togglz-Flag `RESOURCE_PACK_REQUIRED_KICK`. Es ist **ein reiner
+Notausschalter**: gelesen wird ausschließlich der An/Aus-Zustand, weder eine
+Freigabestufe noch eine Berechtigung des Spielers. Eine Stufe würde bedeuten,
+dass derselbe stumme Client je nach Gruppe getrennt oder eingelassen wird — im
+laufenden Zwischenfall nicht beherrschbar; und ausgerechnet das Team ist die
+unbrauchbarste Stichprobe für die Frage, ob normale Clients das Paket rechtzeitig
+laden. **Wer das Flag im `/season status` sieht, ignoriert bei ihm die Spalten
+Stufe und Zeitfenster.**
+
+Das Flag deckt bewusst beide endgültigen Antworten ab, nicht nur den Timeout:
+Minestom merkt sich das `required`-Bit beim Senden des Pakets und wertet es erst
+bei der Antwort aus. Ein Paket lässt sich damit nicht gegen ein Ablehnen, aber
+gegen einen Timeout erzwingen. Ist das Flag aus, wird dasselbe Paket als optional
+gesendet — sonst zeigte der Client einen Pflicht-Dialog, den der Server nicht
+einlöst.
+
+**Voreinstellung: aktiv.** Ohne `flags.properties` — oder wenn die Datei nicht
+lesbar ist — verhält sich die Lobby wie vor Einführung des Flags und löst das
+Versprechen ein, das der Betreiber mit `"required": true` gegeben hat. Andersherum
+würde eine fehlende Datei eine ausdrückliche Konfiguration stillschweigend zur
+Empfehlung herabstufen. Ein Kick ist außerdem der wiederherstellbare der beiden
+Ausgänge: der Spieler verbindet sich neu, während eine Lobby, die ihr Pflichtpaket
+klammheimlich nicht mehr durchsetzt, erst auffällt, wenn die Texturen bei allen
+falsch sind.
 
 ### Stufe 7 — Portale (optional)
 

--- a/docs/spec-lobby-saison-events.md
+++ b/docs/spec-lobby-saison-events.md
@@ -206,16 +206,36 @@ Abschnitt 6a.
 | US-5.03 | Als Betreiber möchte ich, dass die Berechtigung auch beim Wechsel geprüft wird, damit ein manipulierter Klick nichts bewirkt. | When ein Wechsel zu einem Build-Server angefordert wird, shall die Lobby die Berechtigung erneut prüfen, bevor sie den Spieler weiterleitet. | `Deliver` | Must | offen |
 | US-5.04 | Als Teammitglied möchte ich sehen, welche Build-Server gerade laufen, damit ich nicht auf einen gestoppten klicke. | The Navigator shall nur Build-Server anzeigen, die zum Zeitpunkt des Öffnens als erreichbar gemeldet sind. | CloudNet-Dienstliste | Should | offen |
 
-### Stufe 6 — Resource Packs (später)
+### Stufe 6 — Resource Packs
 
-Bewusst grob gehalten. Ausspezifizierung erst, wenn Stufe 1–4 stehen.
+Konfiguriert über `resource-packs.json` neben dem Server. Ohne diese Datei
+registriert die Lobby keinen der Listener und sendet kein einziges Paket-Paket —
+Rollout-Stand daher überall `aus`, siehe [`rollout-log.md`](rollout-log.md).
 
 | ID | Story | Akzeptanzkriterium (EARS) | Schnittstelle | Priorität | Status |
 |---|---|---|---|---|---|
-| US-6.01 | Als Spieler möchte ich saisonale Texturen sehen, ohne bei jedem Serverwechsel neu zu laden. | The Lobby shall ein Basis-Paket und ein Saison-Paket mit getrennten Kennungen ausliefern. | `resource_pack_push` | Could | offen |
-| US-6.02 | Als Betreiber möchte ich beim Saisonwechsel nur das Saison-Paket tauschen. | When die Saison wechselt, shall die Lobby ausschließlich das Saison-Paket entfernen und ersetzen, nicht alle Pakete. | `resource_pack_pop(uuid)` | Could | offen |
-| US-6.03 | Als Betreiber möchte ich, dass ein hängender Client den Verbindungsaufbau nicht blockiert. | If ein Client nicht innerhalb einer konfigurierten Frist auf die Paketanfrage antwortet, then shall die Lobby fortfahren statt zu warten. | eigener Timeout | Could | offen |
-| US-6.04 | Als Betreiber möchte ich Bedrock-Spieler korrekt behandeln, weil deren gemeldeter Status nicht zutrifft. | If ein Spieler über Geyser verbunden ist, then shall die Lobby ihn nicht anhand des gemeldeten Paketstatus bewerten. | Bedrock-Erkennung | Could | offen |
+| US-6.01 | Als Spieler möchte ich saisonale Texturen sehen, ohne bei jedem Serverwechsel neu zu laden. | The Lobby shall ein Basis-Paket und ein Saison-Paket mit getrennten Kennungen ausliefern. | `resource_pack_push` | Could | umgesetzt |
+| US-6.02 | Als Betreiber möchte ich beim Saisonwechsel nur das Saison-Paket tauschen. | When die Saison wechselt, shall die Lobby ausschließlich das Saison-Paket entfernen und ersetzen, nicht alle Pakete. | `resource_pack_pop(uuid)` | Could | umgesetzt |
+| US-6.03 | Als Betreiber möchte ich, dass ein hängender Client den Verbindungsaufbau nicht blockiert. | If ein Client nicht innerhalb einer konfigurierten Frist auf die Paketanfrage antwortet, then shall die Lobby fortfahren statt zu warten. | eigener Timeout | Could | umgesetzt |
+| US-6.04 | Als Betreiber möchte ich Bedrock-Spieler korrekt behandeln, weil deren gemeldeter Status nicht zutrifft. | If ein Spieler über Geyser verbunden ist, then shall die Lobby ihn nicht anhand des gemeldeten Paketstatus bewerten. | Bedrock-Erkennung | Could | umgesetzt |
+
+**Auslöser für US-6.02:** `ResourcePackSeasonWatcher` liest `resource-packs.json`
+alle fünf Sekunden neu und ruft bei geändertem Saison-Eintrag
+`ResourcePackService.applySeason(…)` auf — auf dem Tick-Thread, damit die
+Paket-Buchführung von Minestom nicht nebenläufig beschrieben wird. Ein Wechsel
+erreicht damit auch die Spieler, die bereits online sind, ohne Neustart. Das
+Basis-Paket, der Timeout und die Bedrock-Einstellung werden bewusst **nicht**
+nachgeladen: das große Basis-Paket unter einer vollen Lobby zu tauschen ist eine
+Neustart-Entscheidung.
+
+**Zum Timeout (US-6.03):** Die Wache ist an ihre Anfrage gebunden (konkretes
+Future plus die Paket-Kennungen dieser Anfrage) und beantwortet die Anfrage
+stellvertretend, statt das Future von außen abzuschließen. Nur so räumt Minestom
+seine eigene Buchführung auf; ein von außen abgeschlossenes Future bleibt im
+Spielerobjekt stehen und jede spätere Konfigurationsphase wartet dann auf gar
+kein Paket mehr. Für ein als `required` konfiguriertes Paket bedeutet die
+stellvertretende Antwort einen Kick — dieselbe Regel, die Minestom auf jede
+andere endgültige Antwort anwendet.
 
 ### Stufe 7 — Portale (optional)
 


### PR DESCRIPTION
Stacked on #214. Implements spec Stage 6 — US-6.01 … US-6.04. **106 tests green.**

The spec marks this stage `Could` and deliberately sketched. This builds the mechanism only: no seasonal content, no command, and **a lobby with no pack configured behaves exactly as it does today** — zero push packets, zero pop packets, no file written. That is asserted.

## The model

One large base pack with a stable id plus a small per-season delta with its own id, swapped by popping the season id and pushing its successor. The base pack stays in the client cache across a season change.

## The four traps, and what a test actually proves

**1. Never `replace(true)`** — Minestom implements it as pop-all-then-push, so the client reloads twice. `ResourcePackDefinition.toRequest(...)` always builds `replace(false)`, and a Cyano test asserts a season change emits exactly **one** `ResourcePackPopPacket` carrying the *old season* id — never a null id, which means clear-all — plus exactly one push, with the base pack still held afterwards.

**2. `ConnectionManager.doConfiguration()` calls `packFuture.join()` with no timeout**, so a client that never answers parks its configuration thread forever. An end-to-end test in `:app` registers the real listener and connects a `TestConnection` that never answers a *required* pack. **The agent verified the test is load-bearing: with the guard disabled it hangs and fails on a 15 s preemptive timeout.** A test that would pass either way proves nothing here.

**3. Geyser lies** — for a required pack it reports ACCEPTED → DOWNLOADED → SUCCESSFULLY_LOADED without the player receiving anything, and the pack status cannot reveal it. Bedrock is therefore detected explicitly (Floodgate's all-zero upper UUID half plus the configurable prefix). A Bedrock player gets no push, no pop, and no entry in the book; where delivery to Bedrock is enabled, a reported success leaves the entry unconfirmed and the `required` flag is dropped so Minestom cannot kick on an invented answer.

**4. Minestom tracks only `pendingResourcePacks`, not what a player holds.** `HeldPackRegistry` keeps that book per player and slot. The client also caches **by URL, not by hash**, so definitions expose `contentAddressed()` and loading warns for any pack URL that does not carry its hash.

## Aves: one type fitted, one did not

`ResourcePackCondition` is reused as-is — `withCondition(slot, condition)` accepts it, so `DefaultResourcePackCondition` gives you kick-on-decline if you want it.

`ResourcePackHandler` does **not** fit, and concretely: it models exactly one pack with no notion of slots, so base+season would mean two handlers with two independent caches and two `GlobalEventHandler` registrations bypassing Titan's `EventNode`. Its cache records *sent*, not *held*, so a declined pack stays cached and is never offered again. `setPack` cannot express `required`. And it has no timeout, no Bedrock check, and no way to pop one pack while keeping another — every one of the four traps sits outside it.

## One thing to decide on review

The timeout guard completes Minestom's `resourcePackFuture` directly, through a public but `@ApiStatus.Internal` accessor. That leaves the field completed, so a later configuration pass for that player would not wait again. Deliberate and documented, but it is the one place this stage reaches into Minestom internals.

## Not verifiable without a hosted pack

That the client really keeps the base cached across a swap; real status timing and CDN failures; Geyser's actual lie (the documented behaviour is encoded, no Geyser is in the loop); Floodgate detection against a live Floodgate.

And one that no code can enforce: the research notes that **CustomModelData does not merge** — a season pack touching an item the base pack already customises replaces its file wholesale and silently drops the base variants. Base and season item ids must stay disjoint. That belongs in the pack build pipeline, which does not exist yet.